### PR TITLE
Add xml comments to important public classes

### DIFF
--- a/FFmpegInterop/FFmpegInteropConfig.h
+++ b/FFmpegInterop/FFmpegInteropConfig.h
@@ -181,7 +181,7 @@ namespace FFmpegInterop
 		///<summary>Default style to use for subtitles.</summary>
 		property TimedTextStyle^ SubtitleStyle;
 		
-		///<summary>Used to enable conversion of ANSII encoded subtitles to Unicode.</summary>
+		///<summary>Enable conversion of ANSI encoded subtitles to UTF-8.</summary>
 		property bool AutoCorrectAnsiSubtitles;
 
 		///<summary>The character encoding used to decode ANSI encoded subtitles. By default, the active windows codepage is used.</summary>
@@ -208,10 +208,6 @@ namespace FFmpegInterop
 
 		///<summary>The default name to use for external subtitle streams.</summary>
 		property String^ DefaultExternalSubtitleStreamName;
-
-		///<summary>Used when the duration of a timed metadata cue could not be resolved.</summary>
-		property TimeSpan DefaultTimedMetadataCueDuration;
-	
 
 internal:
 		/*Internal use:determines if a FFmpegInteropInstance is in frame grabber mode. This mode is used to grab frames from a video stream.*/

--- a/FFmpegInterop/FFmpegInteropConfig.h
+++ b/FFmpegInterop/FFmpegInteropConfig.h
@@ -9,6 +9,7 @@ using namespace Windows::Media::Core;
 
 namespace FFmpegInterop
 {
+	///<summary>This class allows configuring the FFmpegInteropMSS instance.</summary>
 	public ref class FFmpegInteropConfig sealed
 	{
 	public:
@@ -18,12 +19,12 @@ namespace FFmpegInterop
 			PassthroughAudioAAC = false;
 
 			PassthroughVideoH264 = true;
-			PassthroughVideoH264Hi10P = false; // neither Windows codecs nor known HW decoders support Hi10P
+			PassthroughVideoH264Hi10P = false;
 			PassthroughVideoHEVC = true;
 			PassthroughVideoWMV3 = true;
 			PassthroughVideoVC1 = true;
-			PassthroughVideoMPEG2 = false; // requires "MPEG-2 Video Extensions"
-			PassthroughVideoVP9 = false; // requires "VP9 Video Extensions"
+			PassthroughVideoMPEG2 = false;
+			PassthroughVideoVP9 = false;
 
 			VideoOutputAllowIyuv = false;
 			VideoOutputAllow10bit = false;
@@ -101,41 +102,89 @@ namespace FFmpegInterop
 			DefaultExternalSubtitleStreamName = "External Subtitle";
 		};
 
+
+		///<summary>Enable passthrough for MP3 audio.</summary>
 		property bool PassthroughAudioMP3;
+
+		///<summary>Enable passthrough for AAC audio.</summary>
 		property bool PassthroughAudioAAC;
 
+
+
+		///<summary>Allow passthrough for H264 video.</summary>
 		property bool PassthroughVideoH264;
+
+		///<summary>Allow passthrough for H264 video (High10 Profile - 10 Bit). Not recommended: Neither Windows codecs nor known HW decoders support Hi10P!</summary>
 		property bool PassthroughVideoH264Hi10P;
+
+		///<summary>Allow passthrough for HEVC video.</summary>
 		property bool PassthroughVideoHEVC;
+
+		///<summary>Allow passthrough for WMV3 video.</summary>
 		property bool PassthroughVideoWMV3;
+
+		///<summary>Allow passthrough for VC-1 video.</summary>
 		property bool PassthroughVideoVC1;
+
+		///<summary>Allow passthrough for MPEG-2 video. Requires "MPEG-2 Video Extension" from Windows Store.</summary>
 		property bool PassthroughVideoMPEG2;
+
+		///<summary>Allow passthrough for VP9 video. Requires "VP9 Video Extensions" from Windows Store.</summary>
 		property bool PassthroughVideoVP9;
 
+
+
+		///<summary>Allow video output in IYuv format.</summary>
 		property bool VideoOutputAllowIyuv;
+		
+		///<summary>Allow video output in 10bit formats.</summary>
 		property bool VideoOutputAllow10bit;
+		
+		///<summary>Allow video output in BGRA format - required for video transparency.</summary>
 		property bool VideoOutputAllowBgra8;
+		
+		///<summary>Allow video output in NV12 format.</summary>
 		property bool VideoOutputAllowNv12;
 
-		/*The maximum number of broken frames to skipp in a stream before stopping decoding*/
+
+
+		///<summary>The maximum number of broken frames to skipp in a stream before stopping decoding.</summary>
 		property unsigned int SkipErrors;
 
+		///<summary>The maximum number of video decoding threads.</summary>
 		property unsigned int MaxVideoThreads;
+		
+		///<summary>The maximum number of audio decoding threads.</summary>
 		property unsigned int MaxAudioThreads;
 
-		/*The maximum supported playback rate. This is set on the media stream source itself. Does not modify what the transport control default UI shows as available playback speeds. Custom UI necessary*/
+		///<summary>The maximum supported playback rate. This is set on the media stream source itself. 
+		/// This does not modify what the transport control default UI shows as available playback speeds. Custom UI is necessary!</summary>
 		property double MaxSupportedPlaybackRate;
+		
+		///<summary>The buffer size to use for streaming sources (URI based).</summary>
 		property unsigned int StreamBufferSize;
 
+		///<summary>Additional options to use when creating the ffmpeg AVFormatContext.</summary>
 		property PropertySet^ FFmpegOptions;
 
-		property TimedTextRegion^ SubtitleRegion;
-		property TimedTextStyle^ SubtitleStyle;
+
+
+		///<summary>Automatically select subtitles when they have the 'forced' flag set.</summary>
 		property bool AutoSelectForcedSubtitles;
+		
+		///<summary>Use SubtitleRegion and SubtitleStyle from config class, even if custom styles are defined for a subtitle.</summary>
 		property bool OverrideSubtitleStyles;
-		/*Used to force conversion of ANSII encoded subtitles to Unicode.*/
+
+		///<summary>Default region to use for subtitles.</summary>
+		property TimedTextRegion^ SubtitleRegion;
+		
+		///<summary>Default style to use for subtitles.</summary>
+		property TimedTextStyle^ SubtitleStyle;
+		
+		///<summary>Used to enable conversion of ANSII encoded subtitles to Unicode.</summary>
 		property bool AutoCorrectAnsiSubtitles;
-		/*The code page used to decode ANSII encoded subtitles. By default, the active windows codepage is used*/
+
+		///<summary>The character encoding used to decode ANSI encoded subtitles. By default, the active windows codepage is used.</summary>
 		property CharacterEncoding^ AnsiSubtitleEncoding
 		{
 			void set(CharacterEncoding^ value)
@@ -150,13 +199,21 @@ namespace FFmpegInterop
 			}
 		}
 
+
+		///<summary>The default name to use for audio streams.</summary>
 		property String^ DefaultAudioStreamName;
+
+		///<summary>The default name to use for subtitle streams.</summary>
 		property String^ DefaultSubtitleStreamName;
+
+		///<summary>The default name to use for external subtitle streams.</summary>
 		property String^ DefaultExternalSubtitleStreamName;
 
-		/*Used when the duration of a timed metadata cue could not be resolved*/
+		///<summary>Used when the duration of a timed metadata cue could not be resolved.</summary>
 		property TimeSpan DefaultTimedMetadataCueDuration;
-	internal:
+	
+
+internal:
 		/*Internal use:determines if a FFmpegInteropInstance is in frame grabber mode. This mode is used to grab frames from a video stream.*/
 		property bool IsFrameGrabber;
 		/*Internal use:determines if a FFmpegInteropInstance is in external subtitle parser mode. This mode is used to parse files which contain only subtitle streams*/

--- a/FFmpegInterop/FFmpegInteropMSS.h
+++ b/FFmpegInterop/FFmpegInteropMSS.h
@@ -52,13 +52,20 @@ namespace FFmpegInterop
 		UTF8
 	};
 
+	///<summary>This is the main class that allows media playback with ffmpeg.</summary>
 	public ref class FFmpegInteropMSS sealed
 	{
 	public:
+		///<summary>Creates a FFmpegInteropMSS from a stream.</summary>
 		static IAsyncOperation<FFmpegInteropMSS^>^ CreateFromStreamAsync(IRandomAccessStream^ stream, FFmpegInteropConfig^ config);
+
+		///<summary>Creates a FFmpegInteropMSS from a stream.</summary>
 		static IAsyncOperation<FFmpegInteropMSS^>^ CreateFromStreamAsync(IRandomAccessStream^ stream) { return CreateFromStreamAsync(stream, ref new FFmpegInteropConfig()); }
 
+		///<summary>Creates a FFmpegInteropMSS from a Uri.</summary>
 		static IAsyncOperation<FFmpegInteropMSS^>^ CreateFromUriAsync(String^ uri, FFmpegInteropConfig^ config);
+		
+		///<summary>Creates a FFmpegInteropMSS from a Uri.</summary>
 		static IAsyncOperation<FFmpegInteropMSS^>^ CreateFromUriAsync(String^ uri) { return CreateFromUriAsync(uri, ref new FFmpegInteropConfig()); }
 
 		[WFM::Deprecated("Use the CreateFromStreamAsync method.", WFM::DeprecationType::Deprecate, 0x0)]
@@ -74,28 +81,52 @@ namespace FFmpegInterop
 		static FFmpegInteropMSS^ CreateFFmpegInteropMSSFromUri(String^ uri, bool forceAudioDecode, bool forceVideoDecode);
 
 
+		///<summary>Sets audio effects. This replaces any effects which were already set.</summary>
 		void SetAudioEffects(IVectorView<AvEffectDefinition^>^ audioEffects);
+		
+		///<summary>Sets video effects. This replaces any effects which were already set.</summary>
 		void SetVideoEffects(IVectorView<AvEffectDefinition^>^ videoEffects);
+		
+		
+		///<summary>Disables audio effects.</summary>
 		void DisableAudioEffects();
+		
+		///<summary>Disables video effects.</summary>
 		void DisableVideoEffects();
+	
+		///<summary>Extracts an embedded thumbnail, if one is available (see HasThumbnail).</summary>
 		MediaThumbnailData^ ExtractThumbnail();
 
+		///<summary>Gets the MediaStreamSource. Using the MediaStreamSource will prevent subtitles from working. Please use CreateMediaPlaybackItem instead.</summary>
 		MediaStreamSource^ GetMediaStreamSource();
+		
+		///<summary>Creates a MediaPlaybackItem for playback.</summary>
 		MediaPlaybackItem^ CreateMediaPlaybackItem();
+	
+		///<summary>Creates a MediaPlaybackItem for playback which starts at the specified stream offset.</summary>
 		MediaPlaybackItem^ CreateMediaPlaybackItem(TimeSpan startTime);
+		
+		///<summary>Creates a MediaPlaybackItem for playback which starts at the specified stream offset and ends after the specified duration.</summary>
 		MediaPlaybackItem^ CreateMediaPlaybackItem(TimeSpan startTime, TimeSpan durationLimit);
 
+		///<summary>Adds an external subtitle from a stream.</summary>
+		///<param name="stream">The subtitle stream.</param>
+		///<param name="streamName">The name to use for the subtitle.</param>
 		IAsyncOperation<IVectorView<SubtitleStreamInfo^>^>^ AddExternalSubtitleAsync(IRandomAccessStream^ stream, String^ streamName);
 
+		///<summary>Adds an external subtitle from a stream.</summary>
+		///<param name="stream">The subtitle stream.</param>
 		IAsyncOperation<IVectorView<SubtitleStreamInfo^>^>^ AddExternalSubtitleAsync(IRandomAccessStream^ stream)
 		{
 			return AddExternalSubtitleAsync(stream, config->DefaultExternalSubtitleStreamName);
 		}
 
+		///<summary>Destroys the FFmpegInteropMSS instance and releases all resources.</summary>
 		virtual ~FFmpegInteropMSS();
 
 		// Properties
 
+		///<summary>Gets the configuration that has been passed when creating the MSS instance.</summary>
 		property FFmpegInteropConfig^ Configuration
 		{
 			FFmpegInteropConfig^ get()
@@ -104,6 +135,7 @@ namespace FFmpegInterop
 			}
 		}
 
+		///<summary>Gets the duration of the stream. Returns zero, if this is streaming media.</summary>
 		property TimeSpan Duration
 		{
 			TimeSpan get()
@@ -112,21 +144,25 @@ namespace FFmpegInterop
 			};
 		};
 
+		///<summary>Gets video stream information.</summary>
 		property VideoStreamInfo^ VideoStream
 		{
 			VideoStreamInfo^ get() { return videoStreamInfo; }
 		}
 
+		///<summary>Gets audio stream information.</summary>
 		property IVectorView<AudioStreamInfo^>^ AudioStreams
 		{
 			IVectorView<AudioStreamInfo^>^ get() { return audioStreamInfos; }
 		}
 
+		///<summary>Gets subtitle stream information.</summary>
 		property IVectorView<SubtitleStreamInfo^>^ SubtitleStreams
 		{
 			IVectorView<SubtitleStreamInfo^>^ get() { return subtitleStreamInfos; }
 		}
 
+		///<summary>Gets a boolean indication if a thumbnail is embedded in the file.</summary>
 		property bool HasThumbnail
 		{
 			bool get() { return thumbnailStreamIndex; }
@@ -168,6 +204,7 @@ namespace FFmpegInterop
 			};
 		};
 
+		///<summary>Gets the MediaPlaybackItem that was created before by using CreateMediaPlaybackItem.</summary>
 		property MediaPlaybackItem^ PlaybackItem
 		{
 			MediaPlaybackItem^ get()

--- a/FFmpegInterop/FrameGrabber.h
+++ b/FFmpegInterop/FrameGrabber.h
@@ -6,6 +6,8 @@
 using namespace concurrency;
 
 namespace FFmpegInterop {
+
+	/// <summary>Supports grabbing of video frames from a file.</summary>
 	public ref class FrameGrabber sealed
 	{
 


### PR DESCRIPTION
I think it is a good idea to document the important public methods and properties with XML comments, so C# users will get hints in intellisense.