### PR TITLE
Random error fixes

### DIFF
--- a/FFmpegInterop/SubtitleProvider.h
+++ b/FFmpegInterop/SubtitleProvider.h
@@ -17,8 +17,6 @@ namespace FFmpegInterop
 	ref class SubtitleProvider abstract : CompressedSampleProvider
 	{
 
-	private:
-		EventRegistrationToken tickToken;
 
 	internal:
 
@@ -282,7 +280,7 @@ namespace FFmpegInterop
 						{
 							thisInstance->timer = ref new Windows::UI::Xaml::DispatcherTimer();
 							thisInstance->timer->Interval = ToTimeSpan(10000);
-							thisInstance->tickToken = thisInstance->timer->Tick += ref new Windows::Foundation::EventHandler<Platform::Object ^>(thisInstance, &FFmpegInterop::SubtitleProvider::OnTick);
+							thisInstance->timer->Tick += ref new Windows::Foundation::EventHandler<Platform::Object ^>(thisInstance, &FFmpegInterop::SubtitleProvider::OnTick);
 						}
 						thisInstance->timer->Start();
 					}
@@ -336,8 +334,7 @@ namespace FFmpegInterop
 			}
 
 			if (timer != nullptr)
-			{
-				timer->Tick -= tickToken;
+			{				
 				timer->Stop();
 			}
 


### PR DESCRIPTION
This PR is intended to fix some subtitle errors that were introduced when we started using DispatcherTimer.

Sometimes, the instance will get disposed before the timer ticks, causing some strange, hard to track down errors. For starters, I added a weak reference in the SubtitleProvider class when creating the Dispatcher callback, and also unsubscribed the event handler when we stop the timer. This should ensure some better clean-up. I think there is still a problem with instance being disposed when the timer ticked. 

There is still a native error occurring when quickly switching tracks when using MediaPlaybackList, I will keep digging and add more fixes if they are caused by the library. 