### PR TITLE
fix for large frame/package pts values.

### DIFF
--- a/FFmpegInterop/MediaSampleProvider.cpp
+++ b/FFmpegInterop/MediaSampleProvider.cpp
@@ -60,7 +60,7 @@ MediaSampleProvider::MediaSampleProvider(
 		//if start time is AV_NOPTS_VALUE, set it to 0
 		m_nextPacketPts = 0;
 	}
-	else 
+	else
 	{
 		//otherwise set the start time of the first packet to the stream start time.
 		m_nextPacketPts = m_pAvFormatCtx->streams[m_streamIndex]->start_time;
@@ -177,7 +177,7 @@ MediaStreamSample^ MediaSampleProvider::GetNextSample()
 		LONGLONG dur = 0;
 
 		hr = CreateNextSampleBuffer(&buffer, pts, dur);
-
+		
 		if (hr == S_OK)
 		{
 			pts = LONGLONG(av_q2d(m_pAvStream->time_base) * 10000000 * pts) - m_startOffset;
@@ -228,7 +228,7 @@ HRESULT MediaSampleProvider::GetNextPacket(AVPacket** avPacket, LONGLONG & packe
 		*avPacket = packet;
 
 		packetDuration = packet->duration;
-		if (packet->pts != AV_NOPTS_VALUE)
+		if (packet->pts != AV_NOPTS_VALUE && packet->pts >= 0 && packet->pts - m_nextPacketPts < 600000000)
 		{
 			packetPts = packet->pts;
 			// Set the PTS for the next sample if it doesn't one.

--- a/FFmpegInterop/MediaSampleProvider.cpp
+++ b/FFmpegInterop/MediaSampleProvider.cpp
@@ -228,7 +228,8 @@ HRESULT MediaSampleProvider::GetNextPacket(AVPacket** avPacket, LONGLONG & packe
 		*avPacket = packet;
 
 		packetDuration = packet->duration;
-		if (packet->pts != AV_NOPTS_VALUE && packet->pts >= 0 && packet->pts - m_nextPacketPts < 600000000)
+		
+		if (packet->pts != AV_NOPTS_VALUE && packet->pts - m_nextPacketPts < 600000000)
 		{
 			packetPts = packet->pts;
 			// Set the PTS for the next sample if it doesn't one.

--- a/FFmpegInterop/UncompressedSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedSampleProvider.cpp
@@ -113,7 +113,7 @@ HRESULT UncompressedSampleProvider::GetFrameFromFFmpegDecoder(AVFrame* avFrame, 
 		else
 		{
 			// Update the timestamp
-			if (avFrame->pts != AV_NOPTS_VALUE && avFrame->pts >= 0 && avFrame->pts - nextFramePts < 600000000)
+			if (avFrame->pts != AV_NOPTS_VALUE && (!hasNextFramePts || avFrame->pts - nextFramePts < 600000000))
 			{
 				framePts = avFrame->pts;
 			}

--- a/FFmpegInterop/UncompressedSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedSampleProvider.cpp
@@ -27,9 +27,9 @@ UncompressedSampleProvider::UncompressedSampleProvider(
 	AVCodecContext* avCodecCtx,
 	FFmpegInteropConfig^ config,
 	int streamIndex
-): MediaSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex)
+) : MediaSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex)
 {
-	
+
 }
 
 HRESULT UncompressedSampleProvider::CreateNextSampleBuffer(IBuffer^* pBuffer, int64_t& samplePts, int64_t& sampleDuration)
@@ -113,7 +113,7 @@ HRESULT UncompressedSampleProvider::GetFrameFromFFmpegDecoder(AVFrame* avFrame, 
 		else
 		{
 			// Update the timestamp
-			if (avFrame->pts != AV_NOPTS_VALUE)
+			if (avFrame->pts != AV_NOPTS_VALUE && avFrame->pts >= 0 && avFrame->pts - nextFramePts < 600000000)
 			{
 				framePts = avFrame->pts;
 			}
@@ -121,9 +121,10 @@ HRESULT UncompressedSampleProvider::GetFrameFromFFmpegDecoder(AVFrame* avFrame, 
 			{
 				framePts = nextFramePts;
 			}
+
 			frameDuration = avFrame->pkt_duration;
 			nextFramePts = framePts + frameDuration;
-
+			
 			hr = S_OK;
 			break;
 		}

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -238,7 +238,8 @@ HRESULT UncompressedVideoSampleProvider::CreateBufferFromFrame(IBuffer^* pBuffer
 	if (hr == S_OK)
 	{
 		// Try to get the best effort timestamp for the frame.
-		framePts = avFrame->best_effort_timestamp;
+		if (avFrame->best_effort_timestamp != AV_NOPTS_VALUE)
+			framePts = avFrame->best_effort_timestamp;
 		m_interlaced_frame = avFrame->interlaced_frame == 1;
 		m_top_field_first = avFrame->top_field_first == 1;
 		m_chroma_location = avFrame->chroma_location;


### PR DESCRIPTION
This fixes #116 

@lukasf 
The problem seem to be caused by 
framePts  =  avFrame->best_effort_timestamp;
You were right, we did miss a check against AV_NOPTS_VALUE there.
That weird number was actually AV_NOPTS_VALUE but signed. 

I also added a few extra checks on frame/ package pts upstream. This should handle some more possible edge cases. 