### PR TITLE
Remove IKeyValuePair interface implementation

### DIFF
--- a/FFmpegInterop/FFmpegInteropMSS.h
+++ b/FFmpegInterop/FFmpegInteropMSS.h
@@ -140,9 +140,9 @@ namespace FFmpegInterop
 			}
 		}		
 
-		property IVectorView<KeyStringValuePair^>^ MetadataTags
+		property IVectorView<IKeyValuePair<String^, String^>^>^ MetadataTags
 		{
-			IVectorView<KeyStringValuePair^>^ get()
+			IVectorView<IKeyValuePair<String^, String^>^>^ get()
 			{
 				metadata->LoadMetadataTags(avFormatCtx);
 				return metadata->MetadataTags;

--- a/FFmpegInterop/KeyStringValuePair.h
+++ b/FFmpegInterop/KeyStringValuePair.h
@@ -3,13 +3,13 @@ using namespace Platform;
 using namespace Windows::Foundation::Collections;
 
 namespace FFmpegInterop {
-	public ref class KeyStringValuePair sealed : IKeyValuePair<String^, String^>
+	public ref class KeyStringValuePair sealed 
 	{
 		String ^key, ^value;
 
 	public:
 
-		virtual property String^ Key
+		property String^ Key
 		{
 			String^ get()
 			{
@@ -17,7 +17,7 @@ namespace FFmpegInterop {
 			}
 		}
 
-		virtual property String^ Value
+		property String^ Value
 		{
 			String^ get()
 			{

--- a/FFmpegInterop/KeyStringValuePair.h
+++ b/FFmpegInterop/KeyStringValuePair.h
@@ -3,7 +3,7 @@ using namespace Platform;
 using namespace Windows::Foundation::Collections;
 
 namespace FFmpegInterop {
-	public ref class KeyStringValuePair sealed 
+	ref class KeyStringValuePair sealed : IKeyValuePair<String^,String^>
 	{
 		String ^key, ^value;
 
@@ -11,7 +11,7 @@ namespace FFmpegInterop {
 
 		property String^ Key
 		{
-			String^ get()
+			virtual String^ get()
 			{
 				return key;
 			}
@@ -19,7 +19,7 @@ namespace FFmpegInterop {
 
 		property String^ Value
 		{
-			String^ get()
+			virtual String^ get()
 			{
 				return value;
 			}

--- a/FFmpegInterop/MediaMetadata.h
+++ b/FFmpegInterop/MediaMetadata.h
@@ -18,7 +18,7 @@ namespace FFmpegInterop {
 
 	ref class MediaMetadata sealed
 	{
-		Vector<KeyStringValuePair^>^ entries;
+		Vector<IKeyValuePair<String^, String^>^>^ entries;
 		bool tagsLoaded = false;
 	internal:
 
@@ -31,7 +31,7 @@ namespace FFmpegInterop {
 		{
 			if (!tagsLoaded) 
 			{
-				entries = ref new Vector<KeyStringValuePair^>();
+				entries = ref new Vector<IKeyValuePair<String^, String^>^>();
 				if (m_pAvFormatCtx->metadata)
 				{
 					AVDictionaryEntry* entry = NULL;
@@ -48,9 +48,9 @@ namespace FFmpegInterop {
 		}
 	
 
-		property IVectorView<KeyStringValuePair^>^ MetadataTags
+		property IVectorView<IKeyValuePair<String^, String^>^>^ MetadataTags
 		{
-			IVectorView<KeyStringValuePair^>^ get()
+			IVectorView<IKeyValuePair<String^, String^>^>^ get()
 			{
 				return entries->GetView();
 			}

--- a/FFmpegInterop/MediaMetadata.h
+++ b/FFmpegInterop/MediaMetadata.h
@@ -55,11 +55,6 @@ namespace FFmpegInterop {
 			}
 		}
 	
-	public:
-		virtual ~MediaMetadata()
-		{
-			entries->Clear();
-		}
 	};
 
 

--- a/FFmpegInterop/MediaMetadata.h
+++ b/FFmpegInterop/MediaMetadata.h
@@ -24,14 +24,13 @@ namespace FFmpegInterop {
 
 		MediaMetadata()
 		{
-
+			entries = ref new Vector<IKeyValuePair<String^, String^>^>();
 		}
 
 		void LoadMetadataTags(AVFormatContext *m_pAvFormatCtx)
 		{
 			if (!tagsLoaded) 
 			{
-				entries = ref new Vector<IKeyValuePair<String^, String^>^>();
 				if (m_pAvFormatCtx->metadata)
 				{
 					AVDictionaryEntry* entry = NULL;

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/MediaPlayerCS/MediaPlayerCS.csproj
+++ b/Samples/MediaPlayerCS/MediaPlayerCS.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>MediaPlayerCS</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.15063.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Tests/UnitTest.csproj
+++ b/Tests/UnitTest.csproj
@@ -11,8 +11,8 @@
     <AssemblyName>UnitTest</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.15063.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
+    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
This should fix #118 
I also uped the target versions for all projects, so they are all in unison as well as targeting the more modern windows 10 versions.