### PR TITLE
Prevent version check from crashing on irregular version number

### DIFF
--- a/FFmpegInterop/FFmpegVersionInfo.h
+++ b/FFmpegInterop/FFmpegVersionInfo.h
@@ -34,7 +34,7 @@ void CheckFFmpegVersion(String^ current, String^ min)
 
 	if (countV < 2 || countMin < 2)
 	{
-		// don't throw an exception if version number cannot be parsed
+		OutputDebugString(L"Failed to parse ffmpeg version number.");
 	}
 	else if (min1 > v1 || (min1 == v1 && min2 > v2) || (min1 == v1 && min2 == v2 && min3 > v3))
 	{

--- a/FFmpegInterop/FFmpegVersionInfo.h
+++ b/FFmpegInterop/FFmpegVersionInfo.h
@@ -34,7 +34,7 @@ void CheckFFmpegVersion(String^ current, String^ min)
 
 	if (countV < 2 || countMin < 2)
 	{
-		throw ref new COMException(E_UNEXPECTED);
+		// don't throw an exception if version number cannot be parsed
 	}
 	else if (min1 > v1 || (min1 == v1 && min2 > v2) || (min1 == v1 && min2 == v2 && min3 > v3))
 	{


### PR DESCRIPTION
This should fix the problem seen in #130 