### PR TITLE
Use default PlatformToolset and latest WinSDK version.

### DIFF
--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -22,17 +22,9 @@ param(
     [System.IO.FileInfo] $Msys2Bin = 'C:\msys64\usr\bin\bash.exe'
 )
 
-$vsLatestPath = & "$VSInstallerFolder\vswhere.exe" -latest -property installationPath -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+[System.IO.DirectoryInfo] $vsLatestPath = & "$VSInstallerFolder\vswhere.exe" -latest -property installationPath -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
 
 Write-Host "Visual Studio Installation folder: [$vsLatestPath]"
-
-try {
-    $vsLatestDir = [System.IO.DirectoryInfo] $vsLatestPath
-}
-catch {
-    "Could not find Visual Studio installation at [$vsLatestPath]."
-    Exit
-}
 
 # Export full current PATH from environment into MSYS2
 $env:MSYS2_PATH_TYPE = 'inherit'
@@ -124,6 +116,7 @@ foreach ($platform in $Platforms) {
 
     # Build ffmpeg
     & $Msys2Bin --login -x $PSScriptRoot\FFmpegConfig.sh Win10 $platform
-    #ls -Recurse -Include *.pdb .\ffuj\ffmpeg\Output\Windows10\x64\ | cp -Destination .\erasme\
+
+    # Copy PDBs to built binaries dir
     Get-ChildItem -Recurse -Include '*.pdb' .\ffmpeg\Output\Windows10\$platform | Copy-Item -Destination .\ffmpeg\Build\Windows10\$platform\bin\
 }

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -3,6 +3,15 @@ param(
     [ValidateSet('x86', 'x64', 'ARM', 'ARM64')]
     [string[]] $Platforms = ('x86', 'x64', 'ARM', 'ARM64'),
 
+    <#
+        Example values:
+
+        14.1
+        14.2
+        14.16
+        14.16.27023
+        14.23.27820
+    #>
     [version] $VcVersion = '14.1',
 
     <#

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -5,7 +5,6 @@ param(
 
     <#
         Example values:
-
         14.1
         14.2
         14.16

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -1,0 +1,129 @@
+param(
+    <#
+        Example values:
+        8.1
+        10.0.15063.0
+        10.0.17763.0
+        10.0.18362.0
+    #>
+    [string] $WindowsTargetPlatformVersion = '10.0.15063.0',
+
+    [ValidateSet('v141', 'v142')]
+    [string] $PlatformToolset = 'v141',
+
+    [ValidateSet('x86', 'x64', 'ARM', 'ARM64')]
+    [string[]] $Platform = ('x86', 'x64', 'ARM', 'ARM64'),
+
+    [ValidateSet('Debug', 'Release')]
+    [string] $Configuration = 'Release',
+
+    [System.IO.DirectoryInfo] $VSInstallerFolder = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer",
+
+    [System.IO.FileInfo] $Msys2Bin = 'C:\msys64\usr\bin\bash.exe'
+)
+
+$vsLatestPath = & "$VSInstallerFolder\vswhere.exe" -latest -property installationPath -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+
+Write-Host "Visual Studio Installation folder: [$vsLatestPath]"
+
+try {
+    $vsLatestDir = [System.IO.DirectoryInfo] $vsLatestPath
+}
+catch {
+    "Could not find Visual Studio installation at [$vsLatestPath]."
+    Exit
+}
+
+# Export full current PATH from environment into MSYS2
+$env:MSYS2_PATH_TYPE = 'inherit'
+
+if (! (Test-Path $PSScriptRoot\ffmpeg\configure)) {
+    Write-Error 'configure is not found in ffmpeg folder. Ensure this folder is populated with ffmpeg snapshot'
+    Exit
+}
+
+# [$env:PROCESSOR_ARCHITECTURE][$Platform]
+$vcvarsArchs = @{
+    'x86' = @{
+        'x86'   = 'x86'
+        'x64'   = 'x86_amd64'
+        'ARM'   = 'x86_arm'
+        'ARM64' = 'x86_arm64'
+    }
+
+    'AMD64' = @{
+        'x86'   = 'amd64_x86'
+        'x64'   = 'amd64'
+        'ARM'   = 'amd64_arm'
+        'ARM64' = 'amd64_arm64'
+    }
+}
+
+foreach ($platform in $Platforms) {
+
+    Write-Host "Building FFmpeg for Windows 10 apps ${platform}..."
+
+    # Load environment from VCVARS.
+    $vcvarsArch = $vcvarsArchs[$env:PROCESSOR_ARCHITECTURE][$platform]
+    CMD /c "`"$vsLatestDir\VC\Auxiliary\Build\vcvarsall.bat`" $vcvarsArch uwp $WindowsTargetPlatformVersion && SET" | . {
+        PROCESS {
+            if ($_ -match '^([^=]+)=(.*)') {
+                if ($matches[1] -notin 'HOME') {
+                    Set-Item -Path "Env:\$($Matches[1])" -Value $Matches[2]
+                }
+            }
+        }
+    }
+
+    New-Item -ItemType Directory -Force $PSScriptRoot\Libs\Build\$platform -OutVariable libs
+
+    ('lib', 'licenses', 'include', 'build') | ForEach-Object {
+        New-Item -ItemType Directory -Force $libs\$_
+    }
+    # Clean platform-specific build dir.
+    Remove-Item -Force -Recurse $libs\build\*
+
+    MSBuild.exe .\Libs\zlib\SMP\libzlib.vcxproj `
+        /p:OutDir="$libs\build\" `
+        /p:Configuration="${Configuration}WinRT" `
+        /p:Platform=$platform `
+        /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+        /p:PlatformToolset=$PlatformToolset
+
+    Get-ChildItem -Recurse -Include '*.h' $libs\build\libzlib\include | Copy-Item -Destination $libs\include\
+    Copy-Item -Recurse $libs\build\libzlib\licenses\* -Destination $libs\licenses\
+    Copy-Item $libs\build\libzlib\lib\$platform\libzlib_winrt.lib $libs\lib\zlib.lib
+    Copy-Item $libs\build\libzlib\lib\$platform\libzlib_winrt.pdb $libs\lib\zlib.pdb
+
+    MSBuild.exe .\Libs\bzip2\SMP\libbz2.vcxproj `
+        /p:OutDir="$libs\build\" `
+        /p:Configuration="${Configuration}WinRT" `
+        /p:Platform=$platform `
+        /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+        /p:PlatformToolset=$PlatformToolset
+
+    Get-ChildItem -Recurse -Include '*.h' $libs\build\libbz2\include | Copy-Item -Destination $libs\include\
+    Copy-Item -Recurse $libs\build\libbz2\licenses\* -Destination $libs\licenses\
+    Copy-Item $libs\build\libbz2\lib\$platform\libbz2_winrt.lib $libs\lib\bz2.lib
+    Copy-Item $libs\build\libbz2\lib\$platform\libbz2_winrt.pdb $libs\lib\bz2.pdb
+
+    MSBuild.exe .\Libs\bzip2\SMP\libiconv.vcxproj `
+        /p:OutDir="$libs\build\" `
+        /p:Configuration="${Configuration}WinRT" `
+        /p:Platform=$platform `
+        /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+        /p:PlatformToolset=$PlatformToolset
+
+    Get-ChildItem -Recurse -Include '*.h' $libs\build\libiconv\include | Copy-Item -Destination $libs\include\
+    Copy-Item -Recurse $libs\build\libiconv\licenses\* -Destination $libs\licenses\
+    Copy-Item $libs\build\libiconv\lib\$platform\libiconv_winrt.lib $libs\lib\iconv.lib
+    Copy-Item $libs\build\libiconv\lib\$platform\libiconv_winrt.pdb $libs\lib\iconv.pdb
+
+    $env:LIB += ";${libs}\lib"
+    $env:INCLUDE += ";${libs}\include"
+
+    # Build ffmpeg
+    & $Msys2Bin --login -x $PSScriptRoot\FFmpegConfig.sh Win10 $platform
+    #ls -Recurse -Include *.pdb .\ffuj\ffmpeg\Output\Windows10\x64\ | cp -Destination .\erasme\
+    Get-ChildItem -Recurse -Include '*.pdb' .\ffmpeg\Output\Windows10\$platform | Copy-Item -Destination .\ffmpeg\Build\Windows10\$platform\bin\
+}

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -70,7 +70,7 @@ foreach ($platform in $Platforms) {
 
     # Load environment from VCVARS.
     $vcvarsArch = $vcvarsArchs[$env:PROCESSOR_ARCHITECTURE][$platform]
-    CMD /c "`"$vsLatestPath\VC\Auxiliary\Build\vcvarsall.bat`" $vcvarsArch uwp $WindowsTargetPlatformVersion && SET" | . {
+    CMD /c "`"$vsLatestPath\VC\Auxiliary\Build\vcvarsall.bat`" $vcvarsArch uwp $WindowsTargetPlatformVersion -vcvars_ver=$VcVersion && SET" | . {
         PROCESS {
             if ($_ -match '^([^=]+)=(.*)') {
                 if ($matches[1] -notin 'HOME') {

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -12,7 +12,7 @@ param(
     [string] $PlatformToolset = 'v141',
 
     [ValidateSet('x86', 'x64', 'ARM', 'ARM64')]
-    [string[]] $Platform = ('x86', 'x64', 'ARM', 'ARM64'),
+    [string[]] $Platforms = ('x86', 'x64', 'ARM', 'ARM64'),
 
     [ValidateSet('Debug', 'Release')]
     [string] $Configuration = 'Release',
@@ -34,7 +34,7 @@ if (! (Test-Path $PSScriptRoot\ffmpeg\configure)) {
     Exit
 }
 
-# [$env:PROCESSOR_ARCHITECTURE][$Platform]
+# [$env:PROCESSOR_ARCHITECTURE][$platform]
 $vcvarsArchs = @{
     'x86' = @{
         'x86'   = 'x86'

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -10,6 +10,8 @@ param(
         14.16
         14.16.27023
         14.23.27820
+
+        Note. The PlatformToolset will be inferred from this value ('v141', 'v142'...)
     #>
     [version] $VcVersion = '14.1',
 
@@ -20,126 +22,137 @@ param(
         10.0.17763.0
         10.0.18362.0
     #>
-    [version] $WindowsTargetPlatformVersion = '10.0.15063.0',
+    [version] $WindowsTargetPlatformVersion = '10.0.18362.0',
 
     [ValidateSet('Debug', 'Release')]
     [string] $Configuration = 'Release',
 
     [System.IO.DirectoryInfo] $VSInstallerFolder = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer",
 
+    # Set the search criteria for VSWHERE.EXE.
+    [string[]] $VsWhereCriteria = '-latest',
+
     [System.IO.FileInfo] $Msys2Bin = 'C:\msys64\usr\bin\bash.exe'
 )
 
-$buildFunctionScript = {
+function Build-Platform {
+    param (
+        [System.IO.DirectoryInfo] $SolutionDir,
+        [string] $Platform,
+        [string] $Configuration,
+        [version] $WindowsTargetPlatformVersion,
+        [version] $VcVersion,
+        [string] $VsLatestPath,
+        [string] $Msys2Bin = 'C:\msys64\usr\bin\bash.exe'
+    )
 
-    <#
-        Meant to run in its own process (job).
-    #>
-    function Build-Platform {
-        param (
-            [System.IO.DirectoryInfo] $SolutionDir,
-            [string] $Platform,
-            [string] $Configuration,
-            [version] $WindowsTargetPlatformVersion,
-            [version] $VcVersion,
-            [string] $VsLatestPath,
-            [string] $Msys2Bin = 'C:\msys64\usr\bin\bash.exe'
-        )
+    $PSBoundParameters | Out-String
 
-        $PSBoundParameters | Out-String
-
-        $vcvarsArchs = @{
-            'x86' = @{
-                'x86'   = 'x86'
-                'x64'   = 'x86_amd64'
-                'ARM'   = 'x86_arm'
-                'ARM64' = 'x86_arm64'
-            }
-        
-            'AMD64' = @{
-                'x86'   = 'amd64_x86'
-                'x64'   = 'amd64'
-                'ARM'   = 'amd64_arm'
-                'ARM64' = 'amd64_arm64'
-            }
+    $vcvarsArchs = @{
+        'x86' = @{
+            'x86'   = 'x86'
+            'x64'   = 'x86_amd64'
+            'ARM'   = 'x86_arm'
+            'ARM64' = 'x86_arm64'
         }
+    
+        'AMD64' = @{
+            'x86'   = 'amd64_x86'
+            'x64'   = 'amd64'
+            'ARM'   = 'amd64_arm'
+            'ARM64' = 'amd64_arm64'
+        }
+    }
 
-        Write-Host "Building FFmpeg for Windows 10 apps ${Platform}..."
+    Write-Host "Building FFmpeg for Windows 10 apps ${Platform}..."
 
-        # Load environment from VCVARS.
-        $vcvarsArch = $vcvarsArchs[$env:PROCESSOR_ARCHITECTURE][$Platform]
+    # Load environment from VCVARS.
+    $vcvarsArch = $vcvarsArchs[$env:PROCESSOR_ARCHITECTURE][$Platform]
 
-        CMD /c "`"$VsLatestPath\VC\Auxiliary\Build\vcvarsall.bat`" $vcvarsArch uwp $WindowsTargetPlatformVersion -vcvars_ver=$VcVersion && SET" | . {
-            PROCESS {
-                if ($_ -match '^([^=]+)=(.*)') {
-                    if ($Matches[1] -notin 'HOME') {
-                        Set-Item -Path "Env:\$($Matches[1])" -Value $Matches[2]
-                    }
+    CMD /c "`"$VsLatestPath\VC\Auxiliary\Build\vcvarsall.bat`" $vcvarsArch uwp $WindowsTargetPlatformVersion -vcvars_ver=$VcVersion && SET" | . {
+        PROCESS {
+            if ($_ -match '^([^=]+)=(.*)') {
+                if ($Matches[1] -notin 'HOME') {
+                    Set-Item -Path "Env:\$($Matches[1])" -Value $Matches[2]
                 }
             }
         }
+    }
 
-        # 14.16.27023 => v141
-        $platformToolSet = "v$($VcVersion.Major)$("$VcVersion.Minor"[0])"
+    # 14.16.27023 => v141
+    $platformToolSet = "v$($VcVersion.Major)$("$VcVersion.Minor"[0])"
 
-        New-Item -ItemType Directory -Force $SolutionDir\Libs\Build\$Platform -OutVariable libs
+    New-Item -ItemType Directory -Force $SolutionDir\Libs\Build\$Platform -OutVariable libs
 
-        ('lib', 'licenses', 'include', 'build') | ForEach-Object {
-            New-Item -ItemType Directory -Force $libs\$_
-        }
-        # Clean platform-specific build dir.
-        Remove-Item -Force -Recurse $libs\build\*
+    ('lib', 'licenses', 'include', 'build') | ForEach-Object {
+        New-Item -ItemType Directory -Force $libs\$_
+    }
+    # Clean platform-specific build dir.
+    Remove-Item -Force -Recurse $libs\build\*
 
+    try {
         MSBuild.exe $SolutionDir\Libs\zlib\SMP\libzlib.vcxproj `
             /p:OutDir="$libs\build\" `
             /p:Configuration="${Configuration}WinRT" `
             /p:Platform=$Platform `
             /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
             /p:PlatformToolset=$platformToolSet
+    }
+    catch {
+        Exit
+    }
 
-        Get-ChildItem -Recurse -Include '*.h' $libs\build\libzlib\include | Copy-Item -Destination $libs\include\
-        Copy-Item -Recurse $libs\build\libzlib\licenses\* -Destination $libs\licenses\
-        Copy-Item $libs\build\libzlib\lib\$Platform\libzlib_winrt.lib $libs\lib\zlib.lib
-        Copy-Item $libs\build\libzlib\lib\$Platform\libzlib_winrt.pdb $libs\lib\zlib.pdb
+    Get-ChildItem -Recurse -Include '*.h' $libs\build\libzlib\include | Copy-Item -Destination $libs\include\
+    Copy-Item -Recurse $libs\build\libzlib\licenses\* -Destination $libs\licenses\
+    Copy-Item $libs\build\libzlib\lib\$Platform\libzlib_winrt.lib $libs\lib\zlib.lib
+    Copy-Item $libs\build\libzlib\lib\$Platform\libzlib_winrt.pdb $libs\lib\zlib.pdb
 
+    try {
         MSBuild.exe $SolutionDir\Libs\bzip2\SMP\libbz2.vcxproj `
             /p:OutDir="$libs\build\" `
             /p:Configuration="${Configuration}WinRT" `
             /p:Platform=$Platform `
             /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
             /p:PlatformToolset=$platformToolSet
+    }
+    catch {
+        Exit
+    }
 
-        Get-ChildItem -Recurse -Include '*.h' $libs\build\libbz2\include | Copy-Item -Destination $libs\include\
-        Copy-Item -Recurse $libs\build\libbz2\licenses\* -Destination $libs\licenses\
-        Copy-Item $libs\build\libbz2\lib\$Platform\libbz2_winrt.lib $libs\lib\bz2.lib
-        Copy-Item $libs\build\libbz2\lib\$Platform\libbz2_winrt.pdb $libs\lib\bz2.pdb
+    Get-ChildItem -Recurse -Include '*.h' $libs\build\libbz2\include | Copy-Item -Destination $libs\include\
+    Copy-Item -Recurse $libs\build\libbz2\licenses\* -Destination $libs\licenses\
+    Copy-Item $libs\build\libbz2\lib\$Platform\libbz2_winrt.lib $libs\lib\bz2.lib
+    Copy-Item $libs\build\libbz2\lib\$Platform\libbz2_winrt.pdb $libs\lib\bz2.pdb
 
+    try {
         MSBuild.exe $SolutionDir\Libs\libiconv\SMP\libiconv.vcxproj `
             /p:OutDir="$libs\build\" `
             /p:Configuration="${Configuration}WinRT" `
             /p:Platform=$Platform `
             /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
             /p:PlatformToolset=$platformToolSet
-
-        Get-ChildItem -Recurse -Include '*.h' $libs\build\libiconv\include | Copy-Item -Destination $libs\include\
-        Copy-Item -Recurse $libs\build\libiconv\licenses\* -Destination $libs\licenses\
-        Copy-Item $libs\build\libiconv\lib\$Platform\libiconv_winrt.lib $libs\lib\iconv.lib
-        Copy-Item $libs\build\libiconv\lib\$Platform\libiconv_winrt.pdb $libs\lib\iconv.pdb
-
-        $env:LIB += ";${libs}\lib"
-        $env:INCLUDE += ";${libs}\include"
-
-        # Export full current PATH from environment into MSYS2
-        $env:MSYS2_PATH_TYPE = 'inherit'
-
-        # Build ffmpeg
-        & $Msys2Bin --login -x $SolutionDir\FFmpegConfig.sh Win10 $Platform
-
-        Start-Job -ScriptBlock { & $Msys2Bin --login -x $SolutionDir\FFmpegConfig.sh Win10 $Platform } | Receive-Job -Wait
-
-        # Copy PDBs to built binaries dir
-        Get-ChildItem -Recurse -Include '*.pdb' $SolutionDir\ffmpeg\Output\Windows10\$Platform | Copy-Item -Destination $SolutionDir\ffmpeg\Build\Windows10\$Platform\bin\
     }
+    catch {
+        Exit
+    }
+
+    Get-ChildItem -Recurse -Include '*.h' $libs\build\libiconv\include | Copy-Item -Destination $libs\include\
+    Copy-Item -Recurse $libs\build\libiconv\licenses\* -Destination $libs\licenses\
+    Copy-Item $libs\build\libiconv\lib\$Platform\libiconv_winrt.lib $libs\lib\iconv.lib
+    Copy-Item $libs\build\libiconv\lib\$Platform\libiconv_winrt.pdb $libs\lib\iconv.pdb
+
+    $env:LIB += ";${libs}\lib"
+    $env:INCLUDE += ";${libs}\include"
+
+    # Export full current PATH from environment into MSYS2
+    $env:MSYS2_PATH_TYPE = 'inherit'
+
+    # Build ffmpeg
+    & $Msys2Bin --login -x $SolutionDir\FFmpegConfig.sh Win10 $Platform
+
+    # Copy PDBs to built binaries dir
+    Get-ChildItem -Recurse -Include '*.pdb' $SolutionDir\ffmpeg\Output\Windows10\$Platform | `
+        Copy-Item -Destination $SolutionDir\ffmpeg\Build\Windows10\$Platform\bin\
 }
 
 if (! (Test-Path $PSScriptRoot\ffmpeg\configure)) {
@@ -147,29 +160,45 @@ if (! (Test-Path $PSScriptRoot\ffmpeg\configure)) {
     Exit
 }
 
-[System.IO.DirectoryInfo] $vsLatestPath = & "$VSInstallerFolder\vswhere.exe" -latest -property installationPath -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+if (!(Test-Path $Msys2Bin)) {
+
+    $msysFound = $false
+    @( 'C:\msys64', 'C:\msys' ) | ForEach-Object {
+        if (Test-Path $_) {
+            $Msys2Bin = "${_}\usr\bin\bash.exe"
+            $msysFound = $true
+
+            break
+        }
+    }
+
+    # Search for MSYS locations
+    if (! $msysFound) {
+        Write-Error "MSYS2 not found."
+        Exit;
+    }
+}
+
+[System.IO.DirectoryInfo] $vsLatestPath = `
+    & "$VSInstallerFolder\vswhere.exe" `
+    $VsWhereCriteria `
+    -property installationPath `
+    -products * `
+    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
 
 Write-Host "Visual Studio Installation folder: [$vsLatestPath]"
 
 $start = Get-Date
 
 foreach ($platform in $Platforms) {
-
-    #TODO: Pass named parameters and forget about args indexes.
-    Start-Job `
-        -InitializationScript $buildFunctionScript `
-        -ArgumentList $PSScriptRoot, $platform, $Configuration, $WindowsTargetPlatformVersion, $VcVersion, $vsLatestPath, $Msys2Bin `
-        -ScriptBlock {
-            Build-Platform `
-                -SolutionDir $args[0] `
-                -Platform $args[1] `
-                -Configuration $args[2] `
-                -WindowsTargetPlatformVersion $args[3] `
-                -VcVersion $args[4] `
-                -VsLatestPath $args[5] `
-                -Msys2Bin $args[6]
-        } `
-    | Receive-Job -Wait
+    Build-Platform `
+        -SolutionDir "${PSScriptRoot}\" `
+        -Platform $platform `
+        -Configuration 'Release' `
+        -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
+        -VcVersion $VcVersion `
+        -VsLatestPath $vsLatestPath `
+        -Msys2Bin $Msys2Bin
 }
 
 Write-Host 'Time elapsed'

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -30,108 +30,147 @@ param(
     [System.IO.FileInfo] $Msys2Bin = 'C:\msys64\usr\bin\bash.exe'
 )
 
-[System.IO.DirectoryInfo] $vsLatestPath = & "$VSInstallerFolder\vswhere.exe" -latest -property installationPath -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+$buildFunctionScript = {
 
-Write-Host "Visual Studio Installation folder: [$vsLatestPath]"
+    <#
+        Meant to run in its own process (job).
+    #>
+    function Build-Platform {
+        param (
+            [System.IO.DirectoryInfo] $SolutionDir,
+            [string] $Platform,
+            [string] $Configuration,
+            [version] $WindowsTargetPlatformVersion,
+            [version] $VcVersion,
+            [string] $VsLatestPath,
+            [string] $Msys2Bin = 'C:\msys64\usr\bin\bash.exe'
+        )
 
-# Export full current PATH from environment into MSYS2
-$env:MSYS2_PATH_TYPE = 'inherit'
+        $PSBoundParameters | Out-String
+
+        $vcvarsArchs = @{
+            'x86' = @{
+                'x86'   = 'x86'
+                'x64'   = 'x86_amd64'
+                'ARM'   = 'x86_arm'
+                'ARM64' = 'x86_arm64'
+            }
+        
+            'AMD64' = @{
+                'x86'   = 'amd64_x86'
+                'x64'   = 'amd64'
+                'ARM'   = 'amd64_arm'
+                'ARM64' = 'amd64_arm64'
+            }
+        }
+
+        Write-Host "Building FFmpeg for Windows 10 apps ${Platform}..."
+
+        # Load environment from VCVARS.
+        $vcvarsArch = $vcvarsArchs[$env:PROCESSOR_ARCHITECTURE][$Platform]
+
+        CMD /c "`"$VsLatestPath\VC\Auxiliary\Build\vcvarsall.bat`" $vcvarsArch uwp $WindowsTargetPlatformVersion -vcvars_ver=$VcVersion && SET" | . {
+            PROCESS {
+                if ($_ -match '^([^=]+)=(.*)') {
+                    if ($Matches[1] -notin 'HOME') {
+                        Set-Item -Path "Env:\$($Matches[1])" -Value $Matches[2]
+                    }
+                }
+            }
+        }
+
+        # 14.16.27023 => v141
+        $platformToolSet = "v$($VcVersion.Major)$("$VcVersion.Minor"[0])"
+
+        New-Item -ItemType Directory -Force $SolutionDir\Libs\Build\$Platform -OutVariable libs
+
+        ('lib', 'licenses', 'include', 'build') | ForEach-Object {
+            New-Item -ItemType Directory -Force $libs\$_
+        }
+        # Clean platform-specific build dir.
+        Remove-Item -Force -Recurse $libs\build\*
+
+        MSBuild.exe $SolutionDir\Libs\zlib\SMP\libzlib.vcxproj `
+            /p:OutDir="$libs\build\" `
+            /p:Configuration="${Configuration}WinRT" `
+            /p:Platform=$Platform `
+            /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+            /p:PlatformToolset=$platformToolSet
+
+        Get-ChildItem -Recurse -Include '*.h' $libs\build\libzlib\include | Copy-Item -Destination $libs\include\
+        Copy-Item -Recurse $libs\build\libzlib\licenses\* -Destination $libs\licenses\
+        Copy-Item $libs\build\libzlib\lib\$Platform\libzlib_winrt.lib $libs\lib\zlib.lib
+        Copy-Item $libs\build\libzlib\lib\$Platform\libzlib_winrt.pdb $libs\lib\zlib.pdb
+
+        MSBuild.exe $SolutionDir\Libs\bzip2\SMP\libbz2.vcxproj `
+            /p:OutDir="$libs\build\" `
+            /p:Configuration="${Configuration}WinRT" `
+            /p:Platform=$Platform `
+            /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+            /p:PlatformToolset=$platformToolSet
+
+        Get-ChildItem -Recurse -Include '*.h' $libs\build\libbz2\include | Copy-Item -Destination $libs\include\
+        Copy-Item -Recurse $libs\build\libbz2\licenses\* -Destination $libs\licenses\
+        Copy-Item $libs\build\libbz2\lib\$Platform\libbz2_winrt.lib $libs\lib\bz2.lib
+        Copy-Item $libs\build\libbz2\lib\$Platform\libbz2_winrt.pdb $libs\lib\bz2.pdb
+
+        MSBuild.exe $SolutionDir\Libs\libiconv\SMP\libiconv.vcxproj `
+            /p:OutDir="$libs\build\" `
+            /p:Configuration="${Configuration}WinRT" `
+            /p:Platform=$Platform `
+            /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+            /p:PlatformToolset=$platformToolSet
+
+        Get-ChildItem -Recurse -Include '*.h' $libs\build\libiconv\include | Copy-Item -Destination $libs\include\
+        Copy-Item -Recurse $libs\build\libiconv\licenses\* -Destination $libs\licenses\
+        Copy-Item $libs\build\libiconv\lib\$Platform\libiconv_winrt.lib $libs\lib\iconv.lib
+        Copy-Item $libs\build\libiconv\lib\$Platform\libiconv_winrt.pdb $libs\lib\iconv.pdb
+
+        $env:LIB += ";${libs}\lib"
+        $env:INCLUDE += ";${libs}\include"
+
+        # Export full current PATH from environment into MSYS2
+        $env:MSYS2_PATH_TYPE = 'inherit'
+
+        # Build ffmpeg
+        & $Msys2Bin --login -x $SolutionDir\FFmpegConfig.sh Win10 $Platform
+
+        Start-Job -ScriptBlock { & $Msys2Bin --login -x $SolutionDir\FFmpegConfig.sh Win10 $Platform } | Receive-Job -Wait
+
+        # Copy PDBs to built binaries dir
+        Get-ChildItem -Recurse -Include '*.pdb' $SolutionDir\ffmpeg\Output\Windows10\$Platform | Copy-Item -Destination $SolutionDir\ffmpeg\Build\Windows10\$Platform\bin\
+    }
+}
 
 if (! (Test-Path $PSScriptRoot\ffmpeg\configure)) {
     Write-Error 'configure is not found in ffmpeg folder. Ensure this folder is populated with ffmpeg snapshot'
     Exit
 }
 
-# 14.16.27023 => v141
-$platformToolSet = "v$($VcVersion.Major)$("$VcVersion.Minor"[0])"
+[System.IO.DirectoryInfo] $vsLatestPath = & "$VSInstallerFolder\vswhere.exe" -latest -property installationPath -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
 
-# [$env:PROCESSOR_ARCHITECTURE][$platform]
-$vcvarsArchs = @{
-    'x86' = @{
-        'x86'   = 'x86'
-        'x64'   = 'x86_amd64'
-        'ARM'   = 'x86_arm'
-        'ARM64' = 'x86_arm64'
-    }
-
-    'AMD64' = @{
-        'x86'   = 'amd64_x86'
-        'x64'   = 'amd64'
-        'ARM'   = 'amd64_arm'
-        'ARM64' = 'amd64_arm64'
-    }
-}
+Write-Host "Visual Studio Installation folder: [$vsLatestPath]"
 
 $start = Get-Date
 
 foreach ($platform in $Platforms) {
 
-    Write-Host "Building FFmpeg for Windows 10 apps ${platform}..."
-
-    # Load environment from VCVARS.
-    $vcvarsArch = $vcvarsArchs[$env:PROCESSOR_ARCHITECTURE][$platform]
-    CMD /c "`"$vsLatestPath\VC\Auxiliary\Build\vcvarsall.bat`" $vcvarsArch uwp $WindowsTargetPlatformVersion -vcvars_ver=$VcVersion && SET" | . {
-        PROCESS {
-            if ($_ -match '^([^=]+)=(.*)') {
-                if ($matches[1] -notin 'HOME') {
-                    Set-Item -Path "Env:\$($Matches[1])" -Value $Matches[2]
-                }
-            }
-        }
-    }
-
-    New-Item -ItemType Directory -Force $PSScriptRoot\Libs\Build\$platform -OutVariable libs
-
-    ('lib', 'licenses', 'include', 'build') | ForEach-Object {
-        New-Item -ItemType Directory -Force $libs\$_
-    }
-    # Clean platform-specific build dir.
-    Remove-Item -Force -Recurse $libs\build\*
-
-    MSBuild.exe .\Libs\zlib\SMP\libzlib.vcxproj `
-        /p:OutDir="$libs\build\" `
-        /p:Configuration="${Configuration}WinRT" `
-        /p:Platform=$platform `
-        /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
-        /p:PlatformToolset=$platformToolSet
-
-    Get-ChildItem -Recurse -Include '*.h' $libs\build\libzlib\include | Copy-Item -Destination $libs\include\
-    Copy-Item -Recurse $libs\build\libzlib\licenses\* -Destination $libs\licenses\
-    Copy-Item $libs\build\libzlib\lib\$platform\libzlib_winrt.lib $libs\lib\zlib.lib
-    Copy-Item $libs\build\libzlib\lib\$platform\libzlib_winrt.pdb $libs\lib\zlib.pdb
-
-    MSBuild.exe .\Libs\bzip2\SMP\libbz2.vcxproj `
-        /p:OutDir="$libs\build\" `
-        /p:Configuration="${Configuration}WinRT" `
-        /p:Platform=$platform `
-        /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
-        /p:PlatformToolset=$platformToolSet
-
-    Get-ChildItem -Recurse -Include '*.h' $libs\build\libbz2\include | Copy-Item -Destination $libs\include\
-    Copy-Item -Recurse $libs\build\libbz2\licenses\* -Destination $libs\licenses\
-    Copy-Item $libs\build\libbz2\lib\$platform\libbz2_winrt.lib $libs\lib\bz2.lib
-    Copy-Item $libs\build\libbz2\lib\$platform\libbz2_winrt.pdb $libs\lib\bz2.pdb
-
-    MSBuild.exe .\Libs\libiconv\SMP\libiconv.vcxproj `
-        /p:OutDir="$libs\build\" `
-        /p:Configuration="${Configuration}WinRT" `
-        /p:Platform=$platform `
-        /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
-        /p:PlatformToolset=$platformToolSet
-
-    Get-ChildItem -Recurse -Include '*.h' $libs\build\libiconv\include | Copy-Item -Destination $libs\include\
-    Copy-Item -Recurse $libs\build\libiconv\licenses\* -Destination $libs\licenses\
-    Copy-Item $libs\build\libiconv\lib\$platform\libiconv_winrt.lib $libs\lib\iconv.lib
-    Copy-Item $libs\build\libiconv\lib\$platform\libiconv_winrt.pdb $libs\lib\iconv.pdb
-
-    $env:LIB += ";${libs}\lib"
-    $env:INCLUDE += ";${libs}\include"
-
-    # Build ffmpeg
-    & $Msys2Bin --login -x $PSScriptRoot\FFmpegConfig.sh Win10 $platform
-
-    # Copy PDBs to built binaries dir
-    Get-ChildItem -Recurse -Include '*.pdb' .\ffmpeg\Output\Windows10\$platform | Copy-Item -Destination .\ffmpeg\Build\Windows10\$platform\bin\
+    #TODO: Pass named parameters and forget about args indexes.
+    Start-Job `
+        -InitializationScript $buildFunctionScript `
+        -ArgumentList $PSScriptRoot, $platform, $Configuration, $WindowsTargetPlatformVersion, $VcVersion, $vsLatestPath, $Msys2Bin `
+        -ScriptBlock {
+            Build-Platform `
+                -SolutionDir $args[0] `
+                -Platform $args[1] `
+                -Configuration $args[2] `
+                -WindowsTargetPlatformVersion $args[3] `
+                -VcVersion $args[4] `
+                -VsLatestPath $args[5] `
+                -Msys2Bin $args[6]
+        } `
+    | Receive-Job -Wait
 }
 
-Write-Host 'Time elapsed' ' {0}' -f ((Get-Date) - $start)
+Write-Host 'Time elapsed'
+Write-Host (' {0}' -f ((Get-Date) - $start))

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -69,9 +69,6 @@
     <Import Project="FFmpegInteropLibs.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)ffmpeg\Build\Windows10\$(Platform)\include</IncludePath>
-  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -43,7 +43,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -68,7 +68,9 @@
     <Import Project="FFmpegInteropLibs.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)ffmpeg\Build\Windows10\$(Platform)\include</IncludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
@@ -157,14 +159,7 @@
     <ClCompile Include="UncompressedSampleProvider.cpp" />
     <ClCompile Include="UncompressedVideoSampleProvider.cpp" />
     <ClCompile Include="pch.cpp">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -43,12 +43,11 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' &gt;= '16.0'">v142</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -43,7 +43,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' &gt;= '16.0'">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -43,7 +43,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <ConfigurationType>DynamicLibrary</ConfigurationType>

--- a/FFmpegInteropx.nuspec
+++ b/FFmpegInteropx.nuspec
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <description>FFmpeg decoding library for Windows 10 UWP Apps</description>
+    <authors>FFmpegInteropX</authors>
+    <projectUrl>https://github.com/ffmpeginteropx/FFmpegInteropX</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+  </metadata>
+  <files>
+
+    <file src="ffmpeg\Build\Windows10\x64\include\**\*.h" target="include" />
+    <file src="x64\Release\FFmpegInterop\FFmpegInterop.winmd" target="lib\uap10.0" />
+
+    <file src="ffmpeg\Build\Windows10\x64\bin\*.dll"                      target="runtimes\win10-x64\native" />
+    <file src="ffmpeg\Build\Windows10\x64\bin\*.pdb"                      target="runtimes\win10-x64\native" />
+    <file src="FFmpegInterop\x64\Release\FFmpegInterop\FFmpegInterop.dll" target="runtimes\win10-x64\native" />
+    <file src="FFmpegInterop\x64\Release\FFmpegInterop\FFmpegInterop.pdb" target="runtimes\win10-x64\native" />
+
+
+    <file src="ffmpeg\Build\Windows10\x86\bin\*.dll"                      target="runtimes\win10-x86\native" />
+    <file src="ffmpeg\Build\Windows10\x86\bin\*.pdb"                      target="runtimes\win10-x86\native" />
+    <file src="FFmpegInterop\Release\FFmpegInterop\FFmpegInterop.dll" target="runtimes\win10-x86\native" />
+    <file src="FFmpegInterop\Release\FFmpegInterop\FFmpegInterop.pdb" target="runtimes\win10-x86\native" />
+
+  </files>
+</package>

--- a/FFmpegInteropx.nuspec
+++ b/FFmpegInteropx.nuspec
@@ -7,11 +7,10 @@
     <authors>FFmpegInteropX</authors>
     <projectUrl>https://github.com/ffmpeginteropx/FFmpegInteropX</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-  </metadata>
-
     <dependencies>
       <group targetFramework="uap10.0" />
     </dependencies>
+  </metadata>
   <files>
 
     <file src="ffmpeg\Build\Windows10\x64\include\**\*.h" target="include" />

--- a/FFmpegInteropx.nuspec
+++ b/FFmpegInteropx.nuspec
@@ -7,7 +7,7 @@
     <authors>FFmpegInteropX</authors>
     <projectUrl>https://github.com/ffmpeginteropx/FFmpegInteropX</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">Apache-2.0</license>
+    <license type="expression">Apache-2.0 AND LGPL-2.1-or-later AND bzip2-1.0.6 AND Zlib</license>
     <dependencies>
       <group targetFramework="uap10.0" />
     </dependencies>

--- a/FFmpegInteropx.nuspec
+++ b/FFmpegInteropx.nuspec
@@ -7,6 +7,7 @@
     <authors>FFmpegInteropX</authors>
     <projectUrl>https://github.com/ffmpeginteropx/FFmpegInteropX</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
     <dependencies>
       <group targetFramework="uap10.0" />
     </dependencies>

--- a/FFmpegInteropx.nuspec
+++ b/FFmpegInteropx.nuspec
@@ -3,6 +3,7 @@
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
+    <commitId>$commitId$</commitId>
     <description>FFmpeg decoding library for Windows 10 UWP Apps</description>
     <authors>FFmpegInteropX</authors>
     <projectUrl>https://github.com/ffmpeginteropx/FFmpegInteropX</projectUrl>

--- a/FFmpegInteropx.nuspec
+++ b/FFmpegInteropx.nuspec
@@ -3,7 +3,6 @@
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
-    <commitId>$commitId$</commitId>
     <description>FFmpeg decoding library for Windows 10 UWP Apps</description>
     <authors>FFmpegInteropX</authors>
     <projectUrl>https://github.com/ffmpeginteropx/FFmpegInteropX</projectUrl>

--- a/FFmpegInteropx.nuspec
+++ b/FFmpegInteropx.nuspec
@@ -8,6 +8,10 @@
     <projectUrl>https://github.com/ffmpeginteropx/FFmpegInteropX</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>
+
+    <dependencies>
+      <group targetFramework="uap10.0" />
+    </dependencies>
   <files>
 
     <file src="ffmpeg\Build\Windows10\x64\include\**\*.h" target="include" />

--- a/FFmpegInteropx.nuspec
+++ b/FFmpegInteropx.nuspec
@@ -18,11 +18,20 @@
     <file src="FFmpegInterop\x64\Release\FFmpegInterop\FFmpegInterop.dll" target="runtimes\win10-x64\native" />
     <file src="FFmpegInterop\x64\Release\FFmpegInterop\FFmpegInterop.pdb" target="runtimes\win10-x64\native" />
 
-
-    <file src="ffmpeg\Build\Windows10\x86\bin\*.dll"                      target="runtimes\win10-x86\native" />
-    <file src="ffmpeg\Build\Windows10\x86\bin\*.pdb"                      target="runtimes\win10-x86\native" />
+    <file src="ffmpeg\Build\Windows10\x86\bin\*.dll"                  target="runtimes\win10-x86\native" />
+    <file src="ffmpeg\Build\Windows10\x86\bin\*.pdb"                  target="runtimes\win10-x86\native" />
     <file src="FFmpegInterop\Release\FFmpegInterop\FFmpegInterop.dll" target="runtimes\win10-x86\native" />
     <file src="FFmpegInterop\Release\FFmpegInterop\FFmpegInterop.pdb" target="runtimes\win10-x86\native" />
+
+    <file src="ffmpeg\Build\Windows10\ARM\bin\*.dll"                      target="runtimes\win10-arm\native" />
+    <file src="ffmpeg\Build\Windows10\ARM\bin\*.pdb"                      target="runtimes\win10-arm\native" />
+    <file src="FFmpegInterop\ARM\Release\FFmpegInterop\FFmpegInterop.dll" target="runtimes\win10-arm\native" />
+    <file src="FFmpegInterop\ARM\Release\FFmpegInterop\FFmpegInterop.pdb" target="runtimes\win10-arm\native" />
+
+    <file src="ffmpeg\Build\Windows10\ARM64\bin\*.dll"                      target="runtimes\win10-arm64\native" />
+    <file src="ffmpeg\Build\Windows10\ARM64\bin\*.pdb"                      target="runtimes\win10-arm64\native" />
+    <file src="FFmpegInterop\ARM64\Release\FFmpegInterop\FFmpegInterop.dll" target="runtimes\win10-arm64\native" />
+    <file src="FFmpegInterop\ARM64\Release\FFmpegInterop\FFmpegInterop.pdb" target="runtimes\win10-arm64\native" />
 
   </files>
 </package>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositoryPath" value="packages" />
+  </config>
+</configuration>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -7,7 +7,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' &gt;= '16.0'">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '15.0'">10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '15.0'">10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '16.0'">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -12,8 +12,7 @@
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' &gt;= '16.0'">v142</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' &gt;= '16.0'">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '16.0'">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '15.0'">10.0.17763.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -7,8 +7,8 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '16.0'">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '15.0'">10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '16.0'">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
@@ -50,49 +50,49 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -8,7 +8,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' == '16.0'">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(VisualStudioVersion)' &gt;= '16.0'">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.10240.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>


### PR DESCRIPTION
As long as the `WindowsTargetPlatformMinVersion` is set, it shouldn't be necessary to install a specific WinSDK version.
MSVC allows using a shortcut to use the "latest installed": `10.0`. This way, any SDK version greater or equal than the minimum required will work without forcing the user to install or retarget.

Also, the `PlatformToolset` property is not that tightly bound to the VS version. Both `v141` and `v142` can be installed with VS2019.
This change uses the default toolset for the given VS version, so no explicit version handling needs to be done.