### PR TITLE
Update to FFmpeg 4.2.2

### DIFF
--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -31,8 +31,8 @@ if [ "$1" == "Win10" ]; then
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00" \
         --extra-ldflags="-APPCONTAINER WindowsApp.lib" \
         --prefix=../../../Build/Windows10/x86
-        make -j8
-        make install
+        make -j8 || exit
+        make install || exit
         popd
 
     elif [ "$2" == "x64" ]; then
@@ -62,8 +62,8 @@ if [ "$1" == "Win10" ]; then
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00" \
         --extra-ldflags="-APPCONTAINER WindowsApp.lib" \
         --prefix=../../../Build/Windows10/x64
-        make -j8
-        make install
+        make -j8 || exit
+        make install || exit
         popd
 
     elif [ "$2" == "ARM" ]; then
@@ -96,8 +96,8 @@ if [ "$1" == "Win10" ]; then
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00 -D__ARM_PCS_VFP" \
         --extra-ldflags="-APPCONTAINER WindowsApp.lib" \
         --prefix=../../../Build/Windows10/ARM
-        make -j8
-        make install
+        make -j8 || exit
+        make install || exit
         popd
 
     elif [ "$2" == "ARM64" ]; then
@@ -129,8 +129,8 @@ if [ "$1" == "Win10" ]; then
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00 -D__ARM_PCS_VFP" \
         --extra-ldflags="-APPCONTAINER WindowsApp.lib" \
         --prefix=../../../Build/Windows10/ARM64
-        make -j8
-        make install
+        make -j8 || exit
+        make install || exit
         popd
 
     fi

--- a/FFmpegInterop/FFmpegVersionInfo.h
+++ b/FFmpegInterop/FFmpegVersionInfo.h
@@ -49,7 +49,7 @@ namespace FFmpegInterop
 	{
 	public:
 		static property String^ MinimumVersion { String^ get() { return "4.0"; } };
-		static property String^ RecommendedVersion { String^ get() { return "4.1.1"; } };
+		static property String^ RecommendedVersion { String^ get() { return "4.2.1"; } };
 		static property String^ CurrentVersion 
 		{ 
 			String^ get()

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Minimum: **FFmpeg 4.0**
 
 ##### Important: Update of gas-preprocessor required!
 
-The gas-preprocessor on the FFmpeg site is currently out-of-date. Please download it from the following website instead, otherwise you won't be able to compile ARM64 successfully.
+The gas-preprocessor has changed since FFmpeg 4.2. Please download an updated copy here:
 
-https://github.com/libav/gas-preprocessor
+https://github.com/FFmpeg/gas-preprocessor
 
 An exception will be thrown if FFmpegInterop is used with anything lower than the minimum version. The recommended version has been tested and is what we currently recommend to use with FFmpegInteropX.
 
@@ -111,12 +111,6 @@ Your `FFmpegInteropX` folder should look as follows
 ## Installing ffmpeg build tools
 
 Now that you have the FFmpeg source code, you can follow the instructions on how to [build FFmpeg for WinRT](https://trac.ffmpeg.org/wiki/CompilationGuide/WinRT) apps. *Follow the setup instruction very carefully to avoid build issues!! Be very careful not to miss a single step. If you have problems building ffmpeg, go through these steps again, since chances are high that you missed some detail.*
-
-##### Important: Update of gas-preprocessor required!
-
-The gas-preprocessor on the FFmpeg site is currently out-of-date. Please download it from the following website instead, otherwise you won't be able to compile ARM64 successfully.
-
-https://github.com/libav/gas-preprocessor
 
 ### Note
 In case you downloaded yasm 64-bit version you'll also need [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-US/download/details.aspx?id=48145). This package is usually installed with VS 2017 but not with VS2019.  In case it's missing yasm will ouput this error message while building ffmpeg:

--- a/README.md
+++ b/README.md
@@ -56,9 +56,15 @@ Either Visual Studio 2017 or Visual Studio 2019 is required.
 
 ## FFmpeg Version
 
-Recommended: **FFmpeg 4.1.1**
+Recommended: **FFmpeg 4.2.1**
 
 Minimum: **FFmpeg 4.0**
+
+##### Important: Update of gas-preprocessor required!
+
+The gas-preprocessor on the FFmpeg site is currently out-of-date. Please download it from the following website instead, otherwise you won't be able to compile ARM64 successfully.
+
+https://github.com/libav/gas-preprocessor
 
 An exception will be thrown if FFmpegInterop is used with anything lower than the minimum version. The recommended version has been tested and is what we currently recommend to use with FFmpegInteropX.
 
@@ -105,6 +111,12 @@ Your `FFmpegInteropX` folder should look as follows
 ## Installing ffmpeg build tools
 
 Now that you have the FFmpeg source code, you can follow the instructions on how to [build FFmpeg for WinRT](https://trac.ffmpeg.org/wiki/CompilationGuide/WinRT) apps. *Follow the setup instruction very carefully to avoid build issues!! Be very careful not to miss a single step. If you have problems building ffmpeg, go through these steps again, since chances are high that you missed some detail.*
+
+##### Important: Update of gas-preprocessor required!
+
+The gas-preprocessor on the FFmpeg site is currently out-of-date. Please download it from the following website instead, otherwise you won't be able to compile ARM64 successfully.
+
+https://github.com/libav/gas-preprocessor
 
 ### Note
 In case you downloaded yasm 64-bit version you'll also need [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-US/download/details.aspx?id=48145). This package is usually installed with VS 2017 but not with VS2019.  In case it's missing yasm will ouput this error message while building ffmpeg:


### PR DESCRIPTION
- Update FFmpeg submodule
- Update readme to give link to new gas-preprocessor
- Make FFmpeg build script abort when a build error occurs