### PR TITLE
Chapter support

### DIFF
--- a/FFmpegInterop/FFmpegInteropMSS.h
+++ b/FFmpegInterop/FFmpegInteropMSS.h
@@ -176,6 +176,12 @@ namespace FFmpegInterop
 			IVectorView<SubtitleStreamInfo^>^ get() { return subtitleStreamInfos; }
 		}
 
+		///<summary>Gets chapter information.</summary>
+		property IVectorView<ChapterInfo^>^ ChapterInfos
+		{
+			IVectorView<ChapterInfo^>^ get() { return chapterInfos; }
+		}
+
 		///<summary>Gets a boolean indication if a thumbnail is embedded in the file.</summary>
 		property bool HasThumbnail
 		{
@@ -300,6 +306,7 @@ namespace FFmpegInterop
 		VideoStreamInfo^ videoStreamInfo;
 		IVectorView<AudioStreamInfo^>^ audioStreamInfos;
 		IVectorView<SubtitleStreamInfo^>^ subtitleStreamInfos;
+		IVectorView<ChapterInfo^>^ chapterInfos;
 
 		AttachedFileHelper^ attachedFileHelper;
 

--- a/FFmpegInterop/StreamInfo.h
+++ b/FFmpegInterop/StreamInfo.h
@@ -139,4 +139,24 @@ namespace FFmpegInterop
 		TimedMetadataTrack^ track;
 		bool isExternal;
 	};
+
+	public ref class ChapterInfo sealed
+	{
+	public:
+		ChapterInfo(String^ title, TimeSpan startTime, TimeSpan duration)
+		{
+			this->title = title;
+			this->startTime = startTime;
+			this->duration = duration;
+		}
+
+		property String^ Title { String^ get() { return title; } }
+		property TimeSpan StartTime { TimeSpan get() { return startTime; } }
+		property TimeSpan Duration { TimeSpan get() { return duration; } }
+
+	private:
+		String^ title;
+		TimeSpan startTime;
+		TimeSpan duration;
+	};
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ FFmpegInteropX is a much **improved fork** of the original [Microsoft project](g
   - VP9 (Requires "VP9 Video Extensions" from Windows Store)
 - Major performance improvements (zero-copy data handling in all important areas)
 - Frame grabber support
+- Chapter information support
 - API improvements
 - Include zlib and bzlib libraries into ffmpeg for full MKV subtitle support
 - Include iconv for character encoding conversion


### PR DESCRIPTION
This adds chapter support to the library. Chapters can be queried from the FFmpegInteropMSS instance, and they are also passed downstream as chapter metadata stream.

I had this since quite some time, but did not use it. I did find files with chapters, but none of them had meaningful titles. Title was always the time code (e.g. "01:25:14.123") in these files, which is not so much fun to look at. I guess chapter names in BluRay are only graphically encoded in the menus but not digitally available, so any rips will only contain chapter timecodes (if at all) but not chapter titles.

Still pushing this out because it cannot harm to have it in the lib.