### PR TITLE
Build script fixes

### DIFF
--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -82,7 +82,7 @@ function Build-Platform {
     if ($lastexitcode -ne 0) { Exit $lastexitcode }
 
     # 14.16.27023 => v141
-    $platformToolSet = "v$($VcVersion.Major)$($VcVersion.Minor[0])"
+    $platformToolSet = "v$($VcVersion.Major)$("$($VcVersion.Minor)"[0])"
     Write-Host "Platform Toolset: [$platformToolSet]"
 
     New-Item -ItemType Directory -Force $SolutionDir\Libs\Build\$Platform -OutVariable libs

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -41,7 +41,7 @@ function Build-Platform {
         [string] $Platform,
         [string] $Configuration,
         [version] $WindowsTargetPlatformVersion,
-        [version] $VcVersion,
+        [string] $PlatformToolset,
         [string] $VsLatestPath,
         [string] $Msys2Bin = 'C:\msys64\usr\bin\bash.exe'
     )
@@ -64,9 +64,9 @@ function Build-Platform {
         }
     }
 
-    Write-Host "Building FFmpeg for Windows 10 apps ${Platform}..."
-
-    # Load environment from VCVARS.
+       Write-Host "Building FFmpeg for Windows 10 apps ${Platform}..."
+    
+     # Load environment from VCVARS.
     $vcvarsArch = $vcvarsArchs[$env:PROCESSOR_ARCHITECTURE][$Platform]
 
     CMD /c "`"$VsLatestPath\VC\Auxiliary\Build\vcvarsall.bat`" $vcvarsArch uwp $WindowsTargetPlatformVersion -vcvars_ver=$VcVersion && SET" | . {
@@ -81,9 +81,6 @@ function Build-Platform {
 
     if ($lastexitcode -ne 0) { Exit $lastexitcode }
 
-    # 14.16.27023 => v141
-    $platformToolSet = "v$($VcVersion.Major)$("$($VcVersion.Minor)"[0])"
-    Write-Host "Platform Toolset: [$platformToolSet]"
 
     New-Item -ItemType Directory -Force $SolutionDir\Libs\Build\$Platform -OutVariable libs
 
@@ -98,7 +95,7 @@ function Build-Platform {
         /p:Configuration="${Configuration}WinRT" `
         /p:Platform=$Platform `
         /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
-        /p:PlatformToolset=$platformToolSet
+        /p:PlatformToolset=$PlatformToolset
 
     if ($lastexitcode -ne 0) { Exit $lastexitcode }
 
@@ -112,7 +109,7 @@ function Build-Platform {
         /p:Configuration="${Configuration}WinRT" `
         /p:Platform=$Platform `
         /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
-        /p:PlatformToolset=$platformToolSet
+        /p:PlatformToolset=$PlatformToolset
 
     if ($lastexitcode -ne 0) { Exit $lastexitcode }
 
@@ -126,7 +123,7 @@ function Build-Platform {
         /p:Configuration="${Configuration}WinRT" `
         /p:Platform=$Platform `
         /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
-        /p:PlatformToolset=$platformToolSet
+        /p:PlatformToolset=$PlatformToolset
     
     if ($lastexitcode -ne 0) { Exit $lastexitcode }
 
@@ -152,6 +149,10 @@ function Build-Platform {
     Get-ChildItem -Recurse -Include '*.pdb' $SolutionDir\ffmpeg\Output\Windows10\$Platform | `
         Copy-Item -Destination $SolutionDir\ffmpeg\Build\Windows10\$Platform\bin\
 }
+
+Write-Host
+Write-Host "Building FFmpegInteropX..."
+Write-Host
 
 # Stop on all PowerShell command errors
 $ErrorActionPreference = "Stop"
@@ -189,6 +190,17 @@ if (!(Test-Path $Msys2Bin)) {
 
 Write-Host "Visual Studio Installation folder: [$vsLatestPath]"
 
+# 14.16.27023 => v141
+$platformToolSet = "v$($VcVersion.Major)$("$($VcVersion.Minor)"[0])"
+Write-Host "Platform Toolset: [$platformToolSet]"
+
+# Save orignal environment variables
+$oldEnv = @{};
+foreach ($item in Get-ChildItem env:)
+{
+    $oldEnv.Add($item.Name, $item.Value);
+}
+
 $start = Get-Date
 
 foreach ($platform in $Platforms) {
@@ -197,9 +209,22 @@ foreach ($platform in $Platforms) {
         -Platform $platform `
         -Configuration 'Release' `
         -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
-        -VcVersion $VcVersion `
+        -PlatformToolset $platformToolSet `
         -VsLatestPath $vsLatestPath `
         -Msys2Bin $Msys2Bin
+
+    # Restore orignal environment variables
+    foreach ($item in $oldEnv.GetEnumerator())
+    {
+        Set-Item -Path env:"$($item.Name)" -Value $item.Value
+    }
+    foreach ($item in Get-ChildItem env:)
+    {
+        if (!$oldEnv.ContainsKey($item.Name))
+        {
+             Remove-Item -Path env:"$($item.Name)"
+        }
+    }
 }
 
 Write-Host 'Time elapsed'


### PR DESCRIPTION
Some more fixes to the build script.

- Final fix for platform parsing: Works not only for "14.1" or "14.2" but also for "14.22" now
- Capture previous environment and restore after each platform build, to prevent false positive builds when actually vsvars failed. This also solves "Command too long" errors when running the script multiple times from same PS instance (vsvars keeps appending to vars and after few runs it is too much).