### PR TITLE
Support decode size for frame grabber

### DIFF
--- a/FFmpegInterop/FFmpegInteropConfig.h
+++ b/FFmpegInterop/FFmpegInteropConfig.h
@@ -266,6 +266,12 @@ namespace FFmpegInterop
 
 		/*Used to pass additional, specific options to external sub parsers*/
 		property PropertySet^ AdditionalFFmpegSubtitleOptions;
+
+		/*Internal use: Sets the target width for frame grabber.*/
+		property int DecodePixelWidth;
+
+		/*Internal use: Sets the target height for frame grabber.*/
+		property int DecodePixelHeight;
 		
 
 	private:

--- a/FFmpegInterop/FFmpegInteropConfig.h
+++ b/FFmpegInterop/FFmpegInteropConfig.h
@@ -266,13 +266,8 @@ namespace FFmpegInterop
 
 		/*Used to pass additional, specific options to external sub parsers*/
 		property PropertySet^ AdditionalFFmpegSubtitleOptions;
-
-		/*Internal use: Sets the target width for frame grabber.*/
-		property int DecodePixelWidth;
-
-		/*Internal use: Sets the target height for frame grabber.*/
-		property int DecodePixelHeight;
 		
+
 
 	private:
 		CharacterEncoding^ m_CharacterEncoding;

--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -827,8 +827,8 @@ HRESULT FFmpegInteropMSS::InitFFmpegContext()
 				auto videoAspect = ((double)videoStream->m_pAvCodecCtx->width / videoStream->m_pAvCodecCtx->height) / pixelAspect;
 
 				videoStreamInfo = ref new VideoStreamInfo(stream->Name, stream->Language, stream->CodecName, avStream->codecpar->bit_rate, true,
-					avStream->codecpar->width, avStream->codecpar->height,
-					max(avStream->codecpar->bits_per_raw_sample, avStream->codecpar->bits_per_coded_sample), videoAspect, VideoSampleProvider->HardwareAccelerationStatus, VideoSampleProvider->Decoder);
+					avStream->codecpar->width, avStream->codecpar->height, videoAspect,
+					max(avStream->codecpar->bits_per_raw_sample, avStream->codecpar->bits_per_coded_sample), VideoSampleProvider->HardwareAccelerationStatus, VideoSampleProvider->Decoder);
 			}
 		}
 		else if (avStream->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE)

--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -823,9 +823,12 @@ HRESULT FFmpegInteropMSS::InitFFmpegContext()
 
 			if (videoStream)
 			{
+				auto pixelAspect = (double)VideoDescriptor->EncodingProperties->PixelAspectRatio->Numerator / VideoDescriptor->EncodingProperties->PixelAspectRatio->Denominator;
+				auto videoAspect = ((double)videoStream->m_pAvCodecCtx->width / videoStream->m_pAvCodecCtx->height) / pixelAspect;
+
 				videoStreamInfo = ref new VideoStreamInfo(stream->Name, stream->Language, stream->CodecName, avStream->codecpar->bit_rate, true,
 					avStream->codecpar->width, avStream->codecpar->height,
-					max(avStream->codecpar->bits_per_raw_sample, avStream->codecpar->bits_per_coded_sample), VideoSampleProvider->HardwareAccelerationStatus, VideoSampleProvider->Decoder);
+					max(avStream->codecpar->bits_per_raw_sample, avStream->codecpar->bits_per_coded_sample), videoAspect, VideoSampleProvider->HardwareAccelerationStatus, VideoSampleProvider->Decoder);
 			}
 		}
 		else if (avStream->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE)

--- a/FFmpegInterop/StreamInfo.h
+++ b/FFmpegInterop/StreamInfo.h
@@ -75,6 +75,7 @@ namespace FFmpegInterop
 
 			this->pixelWidth = pixelWidth;
 			this->pixelHeight = pixelHeight;
+			this->displayAspectRatio = displayAspectRatio;
 			this->bitsPerSample = bitsPerSample;
 
 			this->hardwareDecoderStatus = hwAccel;

--- a/FFmpegInterop/StreamInfo.h
+++ b/FFmpegInterop/StreamInfo.h
@@ -65,7 +65,7 @@ namespace FFmpegInterop
 	{
 	public:
 		VideoStreamInfo(String^ name, String^ language, String^ codecName, int64 bitrate, bool isDefault,
-			int pixelWidth, int pixelHeight, int bitsPerSample, HardwareDecoderStatus hwAccel, DecoderEngine decoderEngine)
+			int pixelWidth, int pixelHeight, double displayAspectRatio, int bitsPerSample, HardwareDecoderStatus hwAccel, DecoderEngine decoderEngine)
 		{
 			this->name = name;
 			this->language = language;
@@ -89,6 +89,7 @@ namespace FFmpegInterop
 
 		property int PixelWidth { int get() { return pixelWidth; } }
 		property int PixelHeight { int get() { return pixelHeight; } }
+		property double DisplayAspectRatio { double get() { return displayAspectRatio; } }
 		property int BitsPerSample { int get() { return bitsPerSample; } }
 
 		property FFmpegInterop::HardwareDecoderStatus HardwareDecoderStatus {FFmpegInterop::HardwareDecoderStatus get() { return hardwareDecoderStatus; }}
@@ -103,6 +104,7 @@ namespace FFmpegInterop
 
 		int pixelWidth;
 		int pixelHeight;
+		double displayAspectRatio;
 		int bitsPerSample;
 
 		FFmpegInterop::HardwareDecoderStatus hardwareDecoderStatus;

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -338,7 +338,7 @@ AVBufferRef* UncompressedVideoSampleProvider::AllocateBuffer(int totalSize)
 {
 	if (m_config->IsFrameGrabber && TargetBuffer)
 	{
-		auto bufferRef = av_buffer_create(TargetBuffer, totalSize, NULL, NULL, 0);
+		auto bufferRef = av_buffer_create(TargetBuffer, totalSize, [](void*, byte*) {}, NULL, 0);
 		return bufferRef;
 	}
 

--- a/FFmpegInterop/UncompressedVideoSampleProvider.h
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.h
@@ -50,6 +50,8 @@ namespace FFmpegInterop
 		virtual HRESULT CreateBufferFromFrame(IBuffer^* pBuffer, AVFrame* avFrame, int64_t& framePts, int64_t& frameDuration) override;
 		virtual HRESULT SetSampleProperties(MediaStreamSample^ sample) override;
 		AVPixelFormat GetOutputPixelFormat() { return m_OutputPixelFormat; }
+		property int TargetWidth;
+		property int TargetHeight;
 
 	private:
 		void SelectOutputFormat();

--- a/FFmpegInterop/UncompressedVideoSampleProvider.h
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.h
@@ -52,11 +52,12 @@ namespace FFmpegInterop
 		AVPixelFormat GetOutputPixelFormat() { return m_OutputPixelFormat; }
 		property int TargetWidth;
 		property int TargetHeight;
+		property byte* TargetBuffer;
 
 	private:
 		void SelectOutputFormat();
 		HRESULT InitializeScalerIfRequired();
-		HRESULT FillLinesAndBuffer(int* linesize, byte** data, AVBufferRef** buffer);
+		HRESULT FillLinesAndBuffer(int* linesize, byte** data, AVBufferRef** buffer, int width, int height);
 		AVBufferRef* AllocateBuffer(int totalSize);
 		static int get_buffer2(AVCodecContext *avCodecContext, AVFrame *frame, int flags);
 


### PR DESCRIPTION
This allows to specify DecodePixelWidth and DecodePixelHeight on the FrameGrabber. Since we always use software decode with sws_scaler in frame grabber mode, we can use the scaler to directly re-scale to our thumbnail target size. This is much faster than decoding full size, and then using UWP methods to downscale. Especially when grabbing multiple frames from the same file (e.g. seekbar thumbnail scenario), the speed increase is very noticeable for me.

One futher idea I had (not realized here): Directly decode into the IBuffer of a WriteableBitmap or SoftwareBitmap, to save the buffer copy operation.