### PR TITLE
Optimize build parameters for ARM and ARM64

### DIFF
--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -85,7 +85,6 @@ if [ "$1" == "Win10" ]; then
         --arch=arm \
         --as=armasm \
         --cpu=armv7 \
-        --enable-thumb \
         --enable-shared \
         --enable-cross-compile \
         --enable-debug \
@@ -117,8 +116,8 @@ if [ "$1" == "Win10" ]; then
 		--disable-hwaccels \
         --disable-doc \
         --arch=arm64 \
-        --cpu=armv7 \
-        --enable-thumb \
+        --as=armasm64 \
+        --cpu=armv8 \
         --enable-shared \
         --enable-cross-compile \
         --enable-debug \


### PR DESCRIPTION
This should result in better performance for ARM and ARM64.

Using the "enable-thumb" parameter on ARM will actually create slower (but smaller) code. That is why the parameter is not enabled by default and not really recommended.

ARM64 is only supported on armv8 CPUs, so we can specify that as cpu type.