### PR TITLE
Change intermediate and output folder structure

### DIFF
--- a/AppVeyor_Build.bat
+++ b/AppVeyor_Build.bat
@@ -1,3 +1,5 @@
+md Output\NuGet
+
 nuget restore FFmpegInterop.sln
 
 msbuild FFmpegInterop.sln /m /t:build /p:Configuration=Debug;Platform=x86;AppxBundle=Never /verbosity:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" || exit

--- a/Build-FFmpegInteropX.ps1
+++ b/Build-FFmpegInteropX.ps1
@@ -34,8 +34,7 @@ param(
 
     [switch] $ClearBuildFolders,
 
-    [switch] $BuildNugetPackage,
-
+    # If a version string is specified, a NuGet package will be created.
     [string] $NugetPackageVersion = "1.0.0",
 
     # FFmpegInteropX NuGet settings
@@ -75,14 +74,8 @@ function Build-Platform {
 
     if ($ClearBuildFolders) {
         # Clean platform-specific build and output dirs.
-        Remove-Item -Force -Recurse -ErrorAction Ignore $SolutionDir\FFmpegInterop\Intermediate\$Platform\*
-        Remove-Item -Force -Recurse -ErrorAction Ignore $SolutionDir\FFmpegInterop\$Platform\*
-
-        if ($Platform -eq "x86") # x86 build will also create Win32 folders
-        {
-            Remove-Item -Force -Recurse -ErrorAction Ignore $SolutionDir\FFmpegInterop\Intermediate\Win32\*
-            Remove-Item -Force -Recurse -ErrorAction Ignore $SolutionDir\FFmpegInterop\Win32\*
-        }
+        Remove-Item -Force -Recurse -ErrorAction Ignore $SolutionDir\Intermediate\FFmpegInterop\$Platform\*
+        Remove-Item -Force -Recurse -ErrorAction Ignore $SolutionDir\Output\FFmpegInterop\$Platform\*
     }
 
     MSBuild.exe $SolutionDir\FFmpegInterop\FFmpegInterop.vcxproj `
@@ -168,12 +161,13 @@ foreach ($platform in $Platforms) {
     }
 }
 
-if ($success -and $BuildNugetPackage)
+if ($success -and $NugetPackageVersion)
 {
     nuget pack .\FFmpegInteropX.nuspec `
         -Properties "id=FFmpegInteropX;repositoryUrl=$FFmpegInteropXUrl;repositoryBranch=$FFmpegInteropXBranch;repositoryCommit=$FFmpegInteropXCommit" `
         -Version $NugetPackageVersion `
-        -Symbols -SymbolPackageFormat symbols.nupkg
+        -Symbols -SymbolPackageFormat symbols.nupkg `
+        -OutputDirectory "Output\NuGet"
 }
 
 Write-Host

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -11,8 +11,8 @@ variant=$1
 platform=$2
 sharedOrStatic=$3
 
-intDir="$DIR/Output/FFmpeg$variant/$platform/int/ffmpeg"
-outDir="$DIR/FFmpeg$variant/$platform"
+intDir="$DIR/Intermediate/FFmpeg$variant/$platform/int/ffmpeg"
+outDir="$DIR/Output/FFmpeg$variant/$platform"
 
 #Main
 echo "Make $variant $platform $sharedOrStatic $intDir $outDir"
@@ -32,7 +32,7 @@ configureArgs="\
     --enable-libxml2 \
     --enable-iconv \
     --target-os=win32 \
-    --pkg-config=$DIR/Output/pkg-config.exe \
+    --pkg-config=$DIR/Intermediate/pkg-config.exe \
     --prefix=$outDir \
 "
 

--- a/FFmpegInterop/FFmpegInterop.vcxproj
+++ b/FFmpegInterop/FFmpegInterop.vcxproj
@@ -70,8 +70,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <IntDir>Intermediate\$(PlatformTarget)\$(Configuration)\</IntDir>
-    <OutDir>$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>..\Intermediate\$(ProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
+    <OutDir>..\Output\$(ProjectName)\$(PlatformTarget)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -173,6 +173,11 @@
     <None Include="..\Build-FFmpegInteropX.ps1" />
     <None Include="..\FFmpegConfig.sh" />
     <None Include="..\AppVeyor_Build.bat" />
+    <None Include="..\FFmpegInteropX.FFmpegUWP.nuspec" />
+    <None Include="..\FFmpegInteropX.FFmpegUWP.targets" />
+    <None Include="..\FFmpegInteropX.nuspec" />
+    <None Include="..\FFmpegInteropX.targets" />
+    <None Include="..\NuGet.Config" />
     <None Include="..\README-BUILD.md" />
     <None Include="..\README.md" />
     <None Include="FFmpegInteropLibs.props" />

--- a/FFmpegInterop/FFmpegInterop.vcxproj.filters
+++ b/FFmpegInterop/FFmpegInterop.vcxproj.filters
@@ -23,6 +23,9 @@
     <Filter Include="Metadata">
       <UniqueIdentifier>{4bf436be-fb97-4ba4-b842-9406d925ebc6}</UniqueIdentifier>
     </Filter>
+    <Filter Include="NuGet">
+      <UniqueIdentifier>{6ec5dc49-1ce3-43ae-8a32-385d881df05e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -199,6 +202,21 @@
     </None>
     <None Include="..\Build-FFmpegInteropX.ps1">
       <Filter>Build</Filter>
+    </None>
+    <None Include="..\FFmpegInteropX.FFmpegUWP.nuspec">
+      <Filter>NuGet</Filter>
+    </None>
+    <None Include="..\FFmpegInteropX.FFmpegUWP.targets">
+      <Filter>NuGet</Filter>
+    </None>
+    <None Include="..\FFmpegInteropX.nuspec">
+      <Filter>NuGet</Filter>
+    </None>
+    <None Include="..\FFmpegInteropX.targets">
+      <Filter>NuGet</Filter>
+    </None>
+    <None Include="..\NuGet.Config">
+      <Filter>NuGet</Filter>
     </None>
   </ItemGroup>
 </Project>

--- a/FFmpegInterop/FFmpegInteropLibs.props
+++ b/FFmpegInterop/FFmpegInteropLibs.props
@@ -2,11 +2,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)..\FFmpegUWP\$(PlatformTarget)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\Output\FFmpegUWP\$(PlatformTarget)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;%(AdditionalDependencies)</AdditionalDependencies>
-	  <AdditionalLibraryDirectories>$(ProjectDir)..\FFmpegUWP\$(PlatformTarget)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+	  <AdditionalLibraryDirectories>$(ProjectDir)..\Output\FFmpegUWP\$(PlatformTarget)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/FFmpegInteropX.FFmpegUWP.nuspec
+++ b/FFmpegInteropX.FFmpegUWP.nuspec
@@ -15,25 +15,25 @@
   </metadata>
   <files>
 
-    <file src="FFmpegUWP\x64\licenses\*.*"                   target="licenses" />
+    <file src="Output\FFmpegUWP\x64\licenses\*.*"            target="licenses" />
     
-    <file src="FFmpegUWP\x64\include\**\*.h"                 target="include" />
+    <file src="Output\FFmpegUWP\x64\include\**\*.h"          target="include" />
 
-    <file src="FFmpegUWP\x86\bin\*.dll"                      target="runtimes\win10-x86\native" />
-    <file src="FFmpegUWP\x86\bin\*.pdb"                      target="runtimes\win10-x86\native" />
-    <file src="FFmpegUWP\x86\bin\*.lib"                      target="runtimes\win10-x86\native" />
+    <file src="Output\FFmpegUWP\x86\bin\*.dll"               target="runtimes\win10-x86\native" />
+    <file src="Output\FFmpegUWP\x86\bin\*.pdb"               target="runtimes\win10-x86\native" />
+    <file src="Output\FFmpegUWP\x86\bin\*.lib"               target="runtimes\win10-x86\native" />
 
-    <file src="FFmpegUWP\x64\bin\*.dll"                      target="runtimes\win10-x64\native" />
-    <file src="FFmpegUWP\x64\bin\*.pdb"                      target="runtimes\win10-x64\native" />
-    <file src="FFmpegUWP\x64\bin\*.lib"                      target="runtimes\win10-x64\native" />
+    <file src="Output\FFmpegUWP\x64\bin\*.dll"               target="runtimes\win10-x64\native" />
+    <file src="Output\FFmpegUWP\x64\bin\*.pdb"               target="runtimes\win10-x64\native" />
+    <file src="Output\FFmpegUWP\x64\bin\*.lib"               target="runtimes\win10-x64\native" />
 
-    <file src="FFmpegUWP\ARM\bin\*.dll"                      target="runtimes\win10-arm\native" />
-    <file src="FFmpegUWP\ARM\bin\*.pdb"                      target="runtimes\win10-arm\native" />
-    <file src="FFmpegUWP\ARM\bin\*.lib"                      target="runtimes\win10-arm\native" />
+    <file src="Output\FFmpegUWP\ARM\bin\*.dll"               target="runtimes\win10-arm\native" />
+    <file src="Output\FFmpegUWP\ARM\bin\*.pdb"               target="runtimes\win10-arm\native" />
+    <file src="Output\FFmpegUWP\ARM\bin\*.lib"               target="runtimes\win10-arm\native" />
 
-    <file src="FFmpegUWP\ARM64\bin\*.dll"                    target="runtimes\win10-arm64\native" />
-    <file src="FFmpegUWP\ARM64\bin\*.pdb"                    target="runtimes\win10-arm64\native" />
-    <file src="FFmpegUWP\ARM64\bin\*.lib"                    target="runtimes\win10-arm64\native" />
+    <file src="Output\FFmpegUWP\ARM64\bin\*.dll"             target="runtimes\win10-arm64\native" />
+    <file src="Output\FFmpegUWP\ARM64\bin\*.pdb"             target="runtimes\win10-arm64\native" />
+    <file src="Output\FFmpegUWP\ARM64\bin\*.lib"             target="runtimes\win10-arm64\native" />
 
     <file src="FFmpegInteropX.FFmpegUWP.targets"             target="build\native"/>
 

--- a/FFmpegInteropX.nuspec
+++ b/FFmpegInteropX.nuspec
@@ -18,20 +18,20 @@
   </metadata>
   <files>
 
-    <file src="FFmpegInterop\x64\Release\FFmpegInterop.winmd"   target="lib\uap10.0" />
-    <file src="FFmpegInterop\x64\Release\FFmpegInterop.xml"     target="lib\uap10.0" />
+    <file src="Output\FFmpegInterop\x64\Release\FFmpegInterop.winmd"   target="lib\uap10.0" />
+    <file src="Output\FFmpegInterop\x64\Release\FFmpegInterop.xml"     target="lib\uap10.0" />
 
-    <file src="FFmpegInterop\x86\Release\FFmpegInterop.dll"     target="runtimes\win10-x86\native" />
-    <file src="FFmpegInterop\x86\Release\FFmpegInterop.pdb"     target="runtimes\win10-x86\native" />
+    <file src="Output\FFmpegInterop\x86\Release\FFmpegInterop.dll"     target="runtimes\win10-x86\native" />
+    <file src="Output\FFmpegInterop\x86\Release\FFmpegInterop.pdb"     target="runtimes\win10-x86\native" />
 
-    <file src="FFmpegInterop\x64\Release\FFmpegInterop.dll"     target="runtimes\win10-x64\native" />
-    <file src="FFmpegInterop\x64\Release\FFmpegInterop.pdb"     target="runtimes\win10-x64\native" />
+    <file src="Output\FFmpegInterop\x64\Release\FFmpegInterop.dll"     target="runtimes\win10-x64\native" />
+    <file src="Output\FFmpegInterop\x64\Release\FFmpegInterop.pdb"     target="runtimes\win10-x64\native" />
 
-    <file src="FFmpegInterop\ARM\Release\FFmpegInterop.dll"     target="runtimes\win10-arm\native" />
-    <file src="FFmpegInterop\ARM\Release\FFmpegInterop.pdb"     target="runtimes\win10-arm\native" />
+    <file src="Output\FFmpegInterop\ARM\Release\FFmpegInterop.dll"     target="runtimes\win10-arm\native" />
+    <file src="Output\FFmpegInterop\ARM\Release\FFmpegInterop.pdb"     target="runtimes\win10-arm\native" />
 
-    <file src="FFmpegInterop\ARM64\Release\FFmpegInterop.dll"   target="runtimes\win10-arm64\native" />
-    <file src="FFmpegInterop\ARM64\Release\FFmpegInterop.pdb"   target="runtimes\win10-arm64\native" />
+    <file src="Output\FFmpegInterop\ARM64\Release\FFmpegInterop.dll"   target="runtimes\win10-arm64\native" />
+    <file src="Output\FFmpegInterop\ARM64\Release\FFmpegInterop.pdb"   target="runtimes\win10-arm64\native" />
 
     <file src="FFmpegInteropX.targets"                          target="build\native"/>
 

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,4 +3,7 @@
   <config>
     <add key="repositoryPath" value="packages" />
   </config>
+  <packageSources>
+    <add key="LocalPackages" value="Output\NuGet" />
+  </packageSources>
 </configuration>

--- a/README-BUILD.md
+++ b/README-BUILD.md
@@ -153,9 +153,16 @@ Run the build script from CMD:
 
 This script has similar parameters as the `Build-FFmpeg.ps1` script. Check parameters above.
 
-## Integrating FFmpegInterop into your app solution (instead of using NuGet package)
+## Integrating the FFmpegInteropX library into your app solution (instead of using NuGet package)
 
-If you want to integrate FFmpegInterop into your app, you can just add the project file (`FFmpegInterop\FFmpegInterop.vcxproj`) to your app solution as an existing project and add a reference from your main app project to FFmpegInterop. The FFmpegInterop project does not have to be in your app's solution folder. 
+If you want to integrate the FFmpegInteropX library into your app, you can just add the project file (`FFmpegInterop\FFmpegInterop.vcxproj`) to your app solution as an existing project and add a reference from your main app project to FFmpegInterop. The FFmpegInterop project does not have to be in your app's solution folder. This allows you to debug into the library.
+
+
+## Integrating custom FFmpeg builds into your app solution using NuGet
+
+When you build FFmpeg UWP and specify a NuGet package version, a package will be created automatically. When you open the FFmpegInteropX solution and click "Manage NuGet packages for Solution", select "LocalPackages" as package source in the top right area. Now you can easily select your latest build and install it into the sample projects. If you want to try the build in your own app, you need to create a NuGet.config file in your app's solution folder, similar to the one in our repo, and have it point to the FFmpegInteropX Output\NuGet folder.
+
+## Integrating custom FFmpeg builds into your app solution without NuGet
 
 Instead of using the FFmpegInteropX.FFmpegUWP NuGet package, you can also manually reference your custom built ffmpeg dll files for the platform you are building. Best is to manually edit your app's project file. This allows you to refer the dlls built for the current platform using $BuildPlatform parameter.
 

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -67,10 +67,18 @@
     <PackageCertificateKeyFile>$(SolutionDir)FFmpegInterop.pfx</PackageCertificateKeyFile>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
     <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>arm64</AppxBundlePlatforms>
+    <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppInstallerUpdateFrequency>1</AppInstallerUpdateFrequency>
     <AppInstallerCheckForUpdateFrequency>OnApplicationRun</AppInstallerCheckForUpdateFrequency>
+    <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
+    <AppxPackageDir>$(SolutionDir)Output\AppPackages\MediaPlayerCPP\</AppxPackageDir>
+    <GenerateTestArtifacts>True</GenerateTestArtifacts>
+    <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutDir>..\..\Output\$(ProjectName)\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>..\..\Intermediate\$(ProjectName)\$(PlatformTarget)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/Samples/MediaPlayerCS/MediaPlayerCS.csproj
+++ b/Samples/MediaPlayerCS/MediaPlayerCS.csproj
@@ -24,9 +24,11 @@
     <AppxBundlePlatforms>x86</AppxBundlePlatforms>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
-    <AppxPackageDir>$(SolutionDir)AppPackages\MediaPlayerCS\</AppxPackageDir>
+    <AppxPackageDir>$(SolutionDir)Output\AppPackages\MediaPlayerCS\</AppxPackageDir>
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
+    <BaseOutputPath>$(SolutionDir)Output\MediaPlayerCS\</BaseOutputPath>
+    <BaseIntermediateOutputPath>$(SolutionDir)Intermediate\MediaPlayerCS\</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>

--- a/Tests/UnitTest.csproj
+++ b/Tests/UnitTest.csproj
@@ -20,6 +20,8 @@
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">14.0</UnitTestPlatformVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <RuntimeIdentifiers>win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot</RuntimeIdentifiers>
+    <BaseOutputPath>$(SolutionDir)Output\UnitTest\</BaseOutputPath>
+    <BaseIntermediateOutputPath>$(SolutionDir)Intermediate\UnitTest\</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This PR changes the output folder sturcture. All projects, including samples and unit tests, will put their intermediate files into the common Intermediate folder. The Output folder will now contain the final output.

This is how the top folder structure will look like after building both FFmpeg, the lib and whole solution:

- Intermediate
  - FFmpegInterop
  - FFmpegUWP
  - MediaPlayerCS
  - MediaPlayerCPP
  - UnitTest

- Output
  - AppPackages (when publishing Samples)
  - FFmpegInterop
  - FFmpegUWP
  - MediaPlayerCS
  - MediaPlayerCPP
  - NuGet (all NuGet packets will be put here)
  - UnitTest

This should make it easier to locate build outputs, and it should put an end to all those scattered Debug, Release, x86, x64, etc etc folders in various places of our various projects. If you need to free up some GBs of space on your disk, just delete the Intermetiate and/or Output folder.

After this PR is merged, I'd recommend you to once clean up your folders. After that, enjoy a clean solution structure.

### Output\NuGet folder: Easy NuGet Package selection for custom builds

All NuGet packets are now built into this folder. I added the folder into our NuGet.config. This makes it easy to directly install and use custom built local packages: Just build a NuGet packet for FFmpegUWP or FFmpegInteropX using our build scripts (pass -NugetPackageVersion <VersionString> and a package will be built). Right-click the solution in VS, click Manage NuGet Packages for Solution, on top right area "Package source" select "LocalPackages". Now you will see the new Package you just built in the available versions list, and you can easily select and install it into one of the samples for testing and debugging. You can put a similar NuGet.config into your own App's Solution folder, pointing to the FFmpegInteropX\Output\NuGet folder, to get the same easy FFmpegInteropX package selection for your own App.

For FFmpegInteropX lib development, it's still best to directly reference FFmpegInteropX. But when doing custom FFmpeg builds, this is now the best and easiest way to test them locally.