### PR TITLE
Make video stream information available through frame grabber

### DIFF
--- a/FFmpegInterop/FrameGrabber.h
+++ b/FFmpegInterop/FrameGrabber.h
@@ -44,6 +44,12 @@ namespace FFmpegInterop {
 		/// <summary>Gets or sets the decode pixel height.</summary>
 		property int DecodePixelHeight;
 
+		/// <summary>Gets the current video stream information.</summary>
+		property VideoStreamInfo^ CurrentVideoStream
+		{
+			VideoStreamInfo^ get() { return interopMSS->VideoStream; }
+		}
+
 		/// <summary>Creates a new FrameGrabber from the specified stream.</summary>
 		static IAsyncOperation<FrameGrabber^>^ CreateFromStreamAsync(IRandomAccessStream^ stream)
 		{


### PR DESCRIPTION
I need the actual video size to calculate optimal thumbnail size. I named it CurrentVideoStream because we might want to be able to switch streams at some point.