### PR TITLE
Fix output pixel size for image files

### DIFF
--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -89,8 +89,18 @@ void UncompressedVideoSampleProvider::SelectOutputFormat()
 		outputMediaSubtype = MediaEncodingSubtypes::Nv12;
 	}
 
-	TargetWidth = decoderWidth = m_pAvCodecCtx->width;
-	TargetHeight = decoderHeight = m_pAvCodecCtx->height;
+	decoderWidth = m_pAvCodecCtx->width;
+	decoderHeight = m_pAvCodecCtx->height;
+
+	if (m_OutputPixelFormat != AV_PIX_FMT_BGRA)
+	{
+		// only BGRA supports unaligned image sizes, all others require 4 pixel alignment
+		decoderWidth = ((decoderWidth - 1) / 4 * 4) + 4;
+		decoderHeight = ((decoderHeight - 1) / 4 * 4) + 4;
+	}
+
+	TargetWidth = decoderWidth;
+	TargetHeight = decoderHeight;
 
 	if (m_config->IsFrameGrabber)
 	{


### PR DESCRIPTION
I found out why some image files could not be opened. It seems that for compressed image formats (NV12/YUV), the image size must be aligned to 4 pixels. If it is not, "media not supported" error is returned on trying to play the source. Only BGRA is fine to have any pixel size, that is why frame grabber worked for these files (it uses BGRA). The problem has never occured with video files, because video encoders usually refuse input that is not aligned.

I fixed this by forcing target image dimensions to be 4 aligned. Images will be displayed correctly during playback (due to setting MF_MT_MINIMUM_DISPLAY_APERTURE to desired rectangle).