### PR TITLE
Fix FFmpeg build for latest MSVC toolkit

### DIFF
--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -131,14 +131,13 @@ function Build-Platform {
         if ($WindowsTarget -eq "UWP") { 
             $configurationName = "${Configuration}WinRT"
             $targetName = "${project}_winrt"
-            $outDir = "$build\"
         }
         else {
             $configurationName = ${Configuration}
             $targetName = ${project}
-            $outDir = "$build\$project\"
         }
         $intDir = "$build\int\$project\"
+        $outDir = "$build\$project\"
 
         MSBuild.exe $SolutionDir\Libs\$folder\SMP\$project.vcxproj `
             /p:OutDir=$outDir `
@@ -147,6 +146,7 @@ function Build-Platform {
             /p:Platform=$Platform `
             /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
             /p:PlatformToolset=$PlatformToolset `
+            /p:ForceImportBeforeCppTargets=$SolutionDir\Libs\LibOverrides.props `
             /p:useenv=true
 
         if ($lastexitcode -ne 0) { throw "Failed to build library $project." }

--- a/Libs/LibOverrides.props
+++ b/Libs/LibOverrides.props
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WindowsAppContainer>false</WindowsAppContainer>
+	<WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+	<Lib>
+		<LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
+	</Lib>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
The latest build tools (VS 16.7) do not compile our FFmpeg libs anymore. It turns out that they don't like the old Windows 8 app parameter "WindowsAppContainer" anymore. I used an override mechanism instead of modifying all our lib project files for every configuration. The override thing also allows me to tweak some compiler settings.

As a side effect, I had to change the output dir. I am really not sure why that was neccessary. Maybe it was disabling that parameter. I never really understood why WinRT builds had a different output dir than Desktop builds. Now they are same, at least on my VS version. It would be great if someone who still uses VS 16.6 or older could try to compile with this change.