### PR TITLE
Allow late-initialization of video pixel format

### DIFF
--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -1296,13 +1296,8 @@ MediaSampleProvider^ FFmpegInteropMSS::CreateVideoStream(AVStream* avStream, int
 			{
 				hr = E_FAIL;
 			}
-			else if (avVideoCodecCtx->pix_fmt == AV_PIX_FMT_NONE)
-			{
-				hr = E_FAIL;
-			}
 			else
 			{
-
 				// Detect video format and create video stream descriptor accordingly
 				result = CreateVideoSampleProvider(avStream, avVideoCodecCtx, index);
 			}

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -171,7 +171,7 @@ HRESULT UncompressedVideoSampleProvider::InitializeScalerIfRequired(AVFrame* avF
 		m_pSwsCtx = sws_getContext(
 			m_pAvCodecCtx->width,
 			m_pAvCodecCtx->height,
-			avFrame->pix_fmt,
+			(AVPixelFormat)avFrame->format,
 			TargetWidth,
 			TargetHeight,
 			m_OutputPixelFormat,

--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -162,7 +162,7 @@ IMediaStreamDescriptor^ UncompressedVideoSampleProvider::CreateStreamDescriptor(
 	return ref new VideoStreamDescriptor(videoProperties);
 }
 
-HRESULT UncompressedVideoSampleProvider::InitializeScalerIfRequired()
+HRESULT UncompressedVideoSampleProvider::InitializeScalerIfRequired(AVFrame* avFrame)
 {
 	HRESULT hr = S_OK;
 	if (m_bUseScaler && !m_pSwsCtx)
@@ -171,7 +171,7 @@ HRESULT UncompressedVideoSampleProvider::InitializeScalerIfRequired()
 		m_pSwsCtx = sws_getContext(
 			m_pAvCodecCtx->width,
 			m_pAvCodecCtx->height,
-			m_pAvCodecCtx->pix_fmt,
+			avFrame->pix_fmt,
 			TargetWidth,
 			TargetHeight,
 			m_OutputPixelFormat,
@@ -206,7 +206,7 @@ HRESULT UncompressedVideoSampleProvider::CreateBufferFromFrame(IBuffer^* pBuffer
 {
 	HRESULT hr = S_OK;
 
-	hr = InitializeScalerIfRequired();
+	hr = InitializeScalerIfRequired(avFrame);
 
 	if (SUCCEEDED(hr))
 	{

--- a/FFmpegInterop/UncompressedVideoSampleProvider.h
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.h
@@ -57,7 +57,7 @@ namespace FFmpegInterop
 
 	private:
 		void SelectOutputFormat();
-		HRESULT InitializeScalerIfRequired();
+		HRESULT InitializeScalerIfRequired(AVFrame* avFrame);
 		HRESULT FillLinesAndBuffer(int* linesize, byte** data, AVBufferRef** buffer, int width, int height);
 		AVBufferRef* AllocateBuffer(int totalSize);
 		static int get_buffer2(AVCodecContext *avCodecContext, AVFrame *frame, int flags);


### PR DESCRIPTION
This will fix video playback of the 4.07GB sample provided in #214. FFmpeg will report PIX_FMT_NONE for the video stream.

In #91, I added a check for PIX_FMT_NONE and reject stream creation for such files. However, we do already delay-init the sws scaler. So we can wait until the first frame is decoded, and use the pixel format from that frame to initialize the scaler. If a frame can be decoded, it will have a correct pixel format.