### PR TITLE
Fix error handling in CPP sample

### DIFF
--- a/Samples/MediaPlayerCPP/MainPage.xaml.h
+++ b/Samples/MediaPlayerCPP/MainPage.xaml.h
@@ -29,6 +29,8 @@
 
 namespace MediaPlayerCPP
 {
+	using namespace Concurrency;
+
 	public ref class MainPage sealed
 	{
 	public:
@@ -39,16 +41,21 @@ namespace MediaPlayerCPP
 
 	private:
 		void OpenLocalFile(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-		void OpenLocalFile(Windows::Storage::StorageFile^ file);
-		void TryOpenLastFile();
+		task<void> OpenLocalFile();
+		task<void> OpenLocalFile(Windows::Storage::StorageFile^ file);
+		task<void> TryOpenLastFile();
 		void URIBoxKeyUp(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
+		task<void> OpenUriStream(Platform::String^ uri);
 		void MediaFailed(Platform::Object^ sender, Windows::UI::Xaml::ExceptionRoutedEventArgs^ e);
 		void ExtractFrame(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		task<void> ExtractFrame();
 		void DisplayErrorMessage(Platform::String^ message);
 		void Page_Loaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void OnButtonPressed(Windows::Media::SystemMediaTransportControls ^sender, Windows::Media::SystemMediaTransportControlsButtonPressedEventArgs ^args);
 		void LoadSubtitleFile(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		task<void> LoadSubtitleFile();
 		void LoadSubtitleFileFFmpeg(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		task<void> LoadSubtitleFileFFmpeg();
 		void OnResolved(Windows::Media::Core::TimedTextSource ^sender, Windows::Media::Core::TimedTextSourceResolveResultEventArgs ^args);
 		void OnTimedMetadataTracksChanged(Windows::Media::Playback::MediaPlaybackItem ^sender, Windows::Foundation::Collections::IVectorChangedEventArgs ^args);
 		void PassthroughVideo_Toggled(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -82,7 +82,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/Samples/MediaPlayerCPP/pch.h
+++ b/Samples/MediaPlayerCPP/pch.h
@@ -25,5 +25,6 @@
 
 #include <collection.h>
 #include <ppltasks.h>
+#include <pplawait.h>
 
 #include "App.xaml.h"


### PR DESCRIPTION
I have switched the CPP sample to use co_await. This finally gives us correct error handling (display error message instead of crash). Only downside is that we cannot use co_await in event handlers.