### PR TITLE
Allow framerate override

### DIFF
--- a/FFmpegInterop/StreamInfo.h
+++ b/FFmpegInterop/StreamInfo.h
@@ -71,7 +71,7 @@ namespace FFmpegInterop
 	{
 	public:
 		VideoStreamInfo(String^ name, String^ language, String^ codecName, int64 bitrate, bool isDefault,
-			int pixelWidth, int pixelHeight, double displayAspectRatio, int bitsPerSample, HardwareDecoderStatus hwAccel, DecoderEngine decoderEngine)
+			int pixelWidth, int pixelHeight, double displayAspectRatio, int bitsPerSample, double framesPerSecond, HardwareDecoderStatus hwAccel, DecoderEngine decoderEngine)
 		{
 			this->name = name;
 			this->language = language;
@@ -83,6 +83,7 @@ namespace FFmpegInterop
 			this->pixelHeight = pixelHeight;
 			this->displayAspectRatio = displayAspectRatio;
 			this->bitsPerSample = bitsPerSample;
+			this->framesPerSecond = framesPerSecond;
 
 			this->hardwareDecoderStatus = hwAccel;
 			this->decoderEngine = decoderEngine;
@@ -98,6 +99,14 @@ namespace FFmpegInterop
 		property int PixelHeight { int get() { return pixelHeight; } }
 		property double DisplayAspectRatio { double get() { return displayAspectRatio; } }
 		property int BitsPerSample { int get() { return bitsPerSample; } }
+		property double FramesPerSecond { double get() { return framesPerSecond; } }
+
+		///<summary>Override the frame rate of the video stream.</summary>
+		///<remarks>
+		/// This must be set before calling CreatePlaybackItem().
+		/// Setting this can cause A/V desync, since it will only affect this stream.
+		/// </remarks>
+		property double FramesPerSecondOverride;
 
 		property FFmpegInterop::HardwareDecoderStatus HardwareDecoderStatus {FFmpegInterop::HardwareDecoderStatus get() { return hardwareDecoderStatus; }}
 		property FFmpegInterop::DecoderEngine DecoderEngine 
@@ -123,6 +132,7 @@ namespace FFmpegInterop
 		int pixelHeight;
 		double displayAspectRatio;
 		int bitsPerSample;
+		double framesPerSecond;
 
 		FFmpegInterop::HardwareDecoderStatus hardwareDecoderStatus;
 		FFmpegInterop::DecoderEngine decoderEngine;

--- a/FFmpegInterop/SubtitleProvider.h
+++ b/FFmpegInterop/SubtitleProvider.h
@@ -74,12 +74,9 @@ namespace FFmpegInterop
 			{
 				try
 				{
-					TimeSpan position;
-					TimeSpan duration;
+					TimeSpan position = ConvertPosition(packet->pts);
+					TimeSpan duration = ConvertDuration(packet->duration);
 					bool isDurationFixed = false;
-
-					position.Duration = LONGLONG(av_q2d(m_pAvStream->time_base) * 10000000 * packet->pts) - m_startOffset;
-					duration.Duration = LONGLONG(av_q2d(m_pAvStream->time_base) * 10000000 * packet->duration);
 
 					auto cue = CreateCue(packet, &position, &duration);
 					if (cue && position.Duration >= 0)

--- a/FFmpegInterop/UncompressedVideoSampleProvider.h
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.h
@@ -55,6 +55,16 @@ namespace FFmpegInterop
 		property int TargetHeight;
 		property byte* TargetBuffer;
 
+		virtual void NotifyCreateSource() override 
+		{			
+			if (VideoInfo->FramesPerSecondOverride > 0 && VideoInfo->FramesPerSecond > 0)
+			{
+				timeBaseFactor *= VideoInfo->FramesPerSecond / VideoInfo->FramesPerSecondOverride;
+			}
+		
+			UncompressedSampleProvider::NotifyCreateSource();
+		}
+
 	private:
 		void SelectOutputFormat();
 		HRESULT InitializeScalerIfRequired(AVFrame* avFrame);


### PR DESCRIPTION
This adds functionality to override the framerate of a video stream. Since there is no native way in FFmpeg to do this, I am patching timestamp and duration of the video samples (this is also how ffmpeg.exe does it).

@mcosmin222 What do you think of my approach of allowing to set the fps override in VideoStreamInfo? I thought that per-stream modifications are more flexible than having this in the config class. Maybe this is not so relevant for video. But for future modifications of audio output formats, one might decide to override the output format of one stream but leave it untouched for a different stream, depending on stream codec or whatever.