### PR TITLE
Fix issue in UncompressedVideoSampleProvider::FillLinesAndBuffer.

### DIFF
--- a/FFmpegInterop/UncompressedVideoSampleProvider.cpp
+++ b/FFmpegInterop/UncompressedVideoSampleProvider.cpp
@@ -362,8 +362,8 @@ HRESULT UncompressedVideoSampleProvider::FillLinesAndBuffer(int* linesize, byte*
 		return E_FAIL;
 	}
 
-	// calculate total size and fill data pointers startig at zero
-	auto totalSize = av_image_fill_pointers(data, m_OutputPixelFormat, height, NULL, linesize);
+	// calculate total size
+	auto totalSize = av_image_get_buffer_size(m_OutputPixelFormat, width, height, 1);
 	if (totalSize <= 0)
 	{
 		return E_FAIL;
@@ -376,12 +376,12 @@ HRESULT UncompressedVideoSampleProvider::FillLinesAndBuffer(int* linesize, byte*
 		return E_OUTOFMEMORY;
 	}
 
-	// shift data pointers to true location
-	auto start = (size_t)buffer[0]->data;
-	data[0] += start;
-	if (data[1]) data[1] += start;
-	if (data[2]) data[2] += start;
-	if (data[3]) data[3] += start;
+	// fill data pointers
+	totalSize = av_image_fill_pointers(data, m_OutputPixelFormat, height, buffer[0]->data, linesize);
+	if (totalSize <= 0)
+	{
+		return E_FAIL;
+	}
 
 	return S_OK;
 }


### PR DESCRIPTION
I found that it's unable to see the video content when I trying to upgrade FFmpegInteropX with FFmpeg 5.0 via [Mile.FFmpeg](https://github.com/ProjectMile/Mile.FFmpeg), I have done some debugging and found that we can't add offsets in `av_image_fill_pointers` when parameter `ptr` is `NULL` because FFmpeg accepts [this patch](https://github.com/FFmpeg/FFmpeg/commit/fc99d595531c0742aae8fe088fc5aad519035f2a) since 5.0.

So, I created a patch for FFmpegInteropX to fix that. Here is the patch.

Kenji Mouri