### PR TITLE
Add Editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sln]
+indent_style = tab
+
+# Xml project files
+[*.{config,csproj,njsproj,props,targets,vcxitems,vcxproj,vcxproj.filters}]
+indent_size = 2
+end_of_line = crlf
+insert_final_newline = false
+
+# XML config files
+[*.{msbuild,props,targets,ruleset,config,nuspec}]
+indent_size = 2
+end_of_line = crlf
+insert_final_newline = false
+
+# Windows Shell scripts
+[*.{cmd,bat,ps1}]
+end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Tools/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 


### PR DESCRIPTION
Allows keeping editor conventions when using supporting IDEs (Visual Studio, Visual Studio Code...).

It prevents mixed tabs in files, trailing whitespaces, conflicting line endings within the same file types.