### PR TITLE
Fix memory leaks

### DIFF
--- a/Source/D3D11VideoSampleProvider.h
+++ b/Source/D3D11VideoSampleProvider.h
@@ -45,6 +45,21 @@ namespace FFmpegInteropX
             }
         }
 
+    public:
+
+        virtual ~D3D11VideoSampleProvider()
+        {
+            ReleaseTrackedSamples();
+        }
+
+        virtual void Flush() override
+        {
+            UncompressedVideoSampleProvider::Flush();
+            ReturnTrackedSamples();
+        }
+
+    internal:
+
         virtual HRESULT CreateBufferFromFrame(IBuffer^* pBuffer, IDirect3DSurface^* surface, AVFrame* avFrame, int64_t& framePts, int64_t& frameDuration) override
         {
             HRESULT hr = S_OK;
@@ -120,8 +135,15 @@ namespace FFmpegInteropX
         {
             if (sample->Direct3D11Surface)
             {
-                samples.insert(reinterpret_cast<IUnknown*>(sample));
-                sample->Processed += ref new Windows::Foundation::TypedEventHandler<Windows::Media::Core::MediaStreamSample^, Platform::Object^>(this, &D3D11VideoSampleProvider::OnProcessed);
+                std::lock_guard<std::mutex> lock(samplesMutex);
+
+                // AddRef the sample on native interface to prevent it from being collected before Processed is called
+                auto sampleNative = reinterpret_cast<IUnknown*>(sample);
+                sampleNative->AddRef();
+
+                // Attach Processed event and store in samples list
+                auto token = sample->Processed += ref new Windows::Foundation::TypedEventHandler<Windows::Media::Core::MediaStreamSample^, Platform::Object^>(this, &D3D11VideoSampleProvider::OnProcessed);
+                samples[sampleNative] = token;
             }
 
             return UncompressedVideoSampleProvider::SetSampleProperties(sample);
@@ -129,11 +151,30 @@ namespace FFmpegInteropX
 
         void OnProcessed(Windows::Media::Core::MediaStreamSample^ sender, Platform::Object^ args)
         {
-            auto unknown = reinterpret_cast<IUnknown*>(sender->Direct3D11Surface);
+            std::lock_guard<std::mutex> lock(samplesMutex);
+
+            auto sampleNative = reinterpret_cast<IUnknown*>(sender);
+            auto mapEntry = samples.find(sampleNative);
+            if (mapEntry == samples.end())
+            {
+                // sample was already released during Flush() or destructor
+            }
+            else
+            {
+                // Release the sample's native interface and return texture to pool
+                sampleNative->Release();
+                samples.erase(mapEntry);
+
+                ReturnTextureToPool(sender);
+            }
+        }
+
+        void ReturnTextureToPool(MediaStreamSample^ sample)
+        {
             IDXGISurface* surface = NULL;
             ID3D11Texture2D* texture = NULL;
 
-            HRESULT hr = DirectXInteropHelper::GetDXGISurface(sender->Direct3D11Surface, &surface);
+            HRESULT hr = DirectXInteropHelper::GetDXGISurface(sample->Direct3D11Surface, &surface);
 
             if (SUCCEEDED(hr))
             {
@@ -145,10 +186,43 @@ namespace FFmpegInteropX
                 texturePool->ReturnTexture(texture);
             }
 
-            samples.erase(reinterpret_cast<IUnknown*>(sender));
-
             SAFE_RELEASE(surface);
             SAFE_RELEASE(texture);
+        }
+
+        void ReleaseTrackedSamples()
+        {
+            std::lock_guard<std::mutex> lock(samplesMutex);
+            for (auto entry : samples)
+            {
+                // detach Processed event and release native interface
+                auto sampleNative = entry.first;
+                auto sample = reinterpret_cast<MediaStreamSample^>(sampleNative);
+
+                sample->Processed -= entry.second;
+                sampleNative->Release();
+            }
+
+            samples.clear();
+        }
+
+        void ReturnTrackedSamples()
+        {
+            std::lock_guard<std::mutex> lock(samplesMutex);
+            for (auto entry : samples)
+            {
+                // detach Processed event and release native interface
+                auto sampleNative = entry.first;
+                auto sample = reinterpret_cast<MediaStreamSample^>(sampleNative);
+
+                sample->Processed -= entry.second;
+                sampleNative->Release();
+
+                // return texture to pool
+                ReturnTextureToPool(sample);
+            }
+
+            samples.clear();
         }
 
         virtual HRESULT SetHardwareDevice(ID3D11Device* device, ID3D11DeviceContext* context, AVBufferRef* avHardwareContext) override
@@ -379,8 +453,8 @@ namespace FFmpegInteropX
         }
 
         TexturePool^ texturePool;
-        std::set<IUnknown*> samples;
-
+        std::map<IUnknown*,EventRegistrationToken> samples;
+        std::mutex samplesMutex;
     };
 }
 

--- a/Source/StringUtils.h
+++ b/Source/StringUtils.h
@@ -22,9 +22,11 @@ namespace FFmpegInteropX
         {
             if (!char_array) return std::wstring(L"");
 
-            std::string s_str = std::string(char_array);
-            std::wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
-            std::wstring wid_str = myconv.from_bytes(s_str);
+            auto required_size = MultiByteToWideChar(CP_UTF8, 0, char_array, -1, NULL, 0);
+            wchar_t* buffer = (wchar_t*)calloc(required_size, sizeof(wchar_t));
+            auto result = MultiByteToWideChar(CP_UTF8, 0, char_array, -1, buffer, required_size);
+            std::wstring wid_str = std::wstring(buffer);
+            free(buffer);
             return wid_str;
         }
 
@@ -39,12 +41,14 @@ namespace FFmpegInteropX
             return ref new Platform::String(input.c_str(), (unsigned int)input.length());
         }
 
-
         static std::string PlatformStringToUtf8String(String^ value)
         {
-            std::wstring strW(value->Begin(), value->Length());
-            std::wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
-            return myconv.to_bytes(strW);
+            int required_size = WideCharToMultiByte(CP_UTF8, 0, value->Data(), -1, NULL, 0, NULL, NULL);
+            char* buffer = (char*)calloc(required_size, sizeof(char));
+            auto result = WideCharToMultiByte(CP_UTF8, 0, value->Data(), -1, buffer, required_size, NULL, NULL);
+            std::string s_str = std::string(buffer);
+            free(buffer);
+            return s_str;
         }
 
     };


### PR DESCRIPTION
I have found a few memory leaks and bugs:
- We did not properly release the AVIOContext, leaking memory
- During string conversion, we need to free the allocated memory.
  std::string will take a copy of the data, so it is safe to release it.
- The fix for TexturePool had some issues
  - We cannot rely on Processed event to come. Especially on seek and shutdown, this caused leakes.
  - So we must cleanup samples on seek and on shutdown
  - Processed event can come anytime, so we need locking to access the tracks sample map