### PR TITLE
Make AttachedFile internal

### DIFF
--- a/Source/AttachedFile.h
+++ b/Source/AttachedFile.h
@@ -13,7 +13,7 @@ using namespace Windows::Storage::Streams;
 
 namespace FFmpegInteropX
 {
-    public ref class AttachedFile sealed
+    ref class AttachedFile sealed
     {
     public:
         property String^ Name { String^ get() { return name; } };


### PR DESCRIPTION
This was never intended to be public. There was no way to create it anyways, so I think it is not really a breaking change.