### PR TITLE
Use lock_guard to simplify and harden mutex handling

### DIFF
--- a/Source/CharacterEncoding.cpp
+++ b/Source/CharacterEncoding.cpp
@@ -12,7 +12,7 @@ namespace winrt::FFmpegInteropX::implementation
     {
         if (internalView == nullptr)
         {
-            auto guard = std::lock_guard(mutex);
+            std::lock_guard lock(mutex);
             try
             {
                 if (internalView == nullptr)

--- a/Source/CharacterEncoding.cpp
+++ b/Source/CharacterEncoding.cpp
@@ -12,7 +12,7 @@ namespace winrt::FFmpegInteropX::implementation
     {
         if (internalView == nullptr)
         {
-            mutex.lock();
+            auto guard = std::lock_guard(mutex);
             try
             {
                 if (internalView == nullptr)
@@ -192,7 +192,6 @@ namespace winrt::FFmpegInteropX::implementation
             {
             }
             internalView = internalMap.GetView();
-            mutex.unlock();
         }
         return internalView;
     }

--- a/Source/CodecChecker.h
+++ b/Source/CodecChecker.h
@@ -74,21 +74,19 @@ namespace winrt::FFmpegInteropX::implementation
         {
             if (!hasCheckedHardwareAcceleration)
             {
-                mutex.lock();
+                auto guard = std::lock_guard(mutex);
 
                 if (!hasCheckedHardwareAcceleration)
                 {
                     PerformCheckHardwareAcceleration();
                     hasCheckedHardwareAcceleration = true;
                 }
-
-                mutex.unlock();
             }
         }
 
         static void Refresh()
         {
-            mutex.lock();
+            auto guard = std::lock_guard(mutex);
 
             PerformCheckHardwareAcceleration();
             hasCheckedHardwareAcceleration = true;
@@ -100,8 +98,6 @@ namespace winrt::FFmpegInteropX::implementation
             hasAskedInstallMpeg2Extension = false;
             hasAskedInstallVP9Extension = false;
             hasAskedInstallHEVCExtension = false;
-
-            mutex.unlock();
         }
 
         static bool CheckIsMpeg2VideoExtensionInstalled()
@@ -129,7 +125,7 @@ namespace winrt::FFmpegInteropX::implementation
         {
             if (!hasCheckedExtension)
             {
-                mutex.lock();
+                auto guard = std::lock_guard(mutex);
 
                 if (!hasCheckedExtension)
                 {
@@ -144,8 +140,6 @@ namespace winrt::FFmpegInteropX::implementation
                     }
                     hasCheckedExtension = true;
                 }
-
-                mutex.unlock();
             }
 
             return isExtensionInstalled;

--- a/Source/CodecChecker.h
+++ b/Source/CodecChecker.h
@@ -74,7 +74,7 @@ namespace winrt::FFmpegInteropX::implementation
         {
             if (!hasCheckedHardwareAcceleration)
             {
-                auto guard = std::lock_guard(mutex);
+                std::lock_guard lock(mutex);
 
                 if (!hasCheckedHardwareAcceleration)
                 {
@@ -86,7 +86,7 @@ namespace winrt::FFmpegInteropX::implementation
 
         static void Refresh()
         {
-            auto guard = std::lock_guard(mutex);
+            std::lock_guard lock(mutex);
 
             PerformCheckHardwareAcceleration();
             hasCheckedHardwareAcceleration = true;
@@ -125,7 +125,7 @@ namespace winrt::FFmpegInteropX::implementation
         {
             if (!hasCheckedExtension)
             {
-                auto guard = std::lock_guard(mutex);
+                std::lock_guard lock(mutex);
 
                 if (!hasCheckedExtension)
                 {

--- a/Source/D3D11VideoSampleProvider.h
+++ b/Source/D3D11VideoSampleProvider.h
@@ -134,7 +134,7 @@ namespace FFmpegInteropX
         {
             if (sample.Direct3D11Surface())
             {
-                std::lock_guard<std::mutex> lock(samplesMutex);
+                std::lock_guard lock(samplesMutex);
 
                 // AddRef the sample on native interface to prevent it from being collected before Processed is called
                 auto sampleNative = sample.as<winrt::Windows::Foundation::IUnknown>();
@@ -149,7 +149,7 @@ namespace FFmpegInteropX
 
         void OnProcessed(MediaStreamSample const& sender, winrt::Windows::Foundation::IInspectable const&)
         {
-            std::lock_guard<std::mutex> lock(samplesMutex);
+            std::lock_guard lock(samplesMutex);
 
             auto sampleNative = sender.as<winrt::Windows::Foundation::IUnknown>();
             auto mapEntry = trackedSamples.find(sampleNative);
@@ -190,7 +190,7 @@ namespace FFmpegInteropX
 
         void ReleaseTrackedSamples()
         {
-            std::lock_guard<std::mutex> lock(samplesMutex);
+            std::lock_guard lock(samplesMutex);
             for (auto &entry : trackedSamples)
             {
                 // detach Processed event and release native interface
@@ -205,7 +205,7 @@ namespace FFmpegInteropX
 
         void ReturnTrackedSamples()
         {
-            std::lock_guard<std::mutex> lock(samplesMutex);
+            std::lock_guard lock(samplesMutex);
             for (auto &entry : trackedSamples)
             {
                 // detach Processed event and release native interface

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -1406,6 +1406,11 @@ namespace winrt::FFmpegInteropX::implementation
             m_pReader.reset();;
         }
 
+        if (fileStreamBuffer)
+        {
+            av_freep(fileStreamBuffer);
+        }
+
         for (auto &x : subtitleStreams)
             x.reset();
         for (auto &x : sampleProviders)

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -44,7 +44,6 @@ namespace winrt::FFmpegInteropX::implementation
         , dispatcher(dispatcher)
     {
         avDict = NULL;
-        fileStreamBuffer = NULL;
         avHardwareContext = NULL;
         avHardwareContextDefault = NULL;
         device = NULL;
@@ -127,6 +126,7 @@ namespace winrt::FFmpegInteropX::implementation
 
         }
 
+        unsigned char* fileStreamBuffer = NULL;
         if (SUCCEEDED(hr))
         {
             // Setup FFmpeg custom IO to access file as stream. This is necessary when accessing any file outside of app installation directory and appdata folder.
@@ -143,6 +143,7 @@ namespace winrt::FFmpegInteropX::implementation
             avIOCtx = avio_alloc_context(fileStreamBuffer, config->StreamBufferSize(), 0, (void*)winrt::get_abi(this), FileStreamRead, 0, FileStreamSeek);
             if (avIOCtx == nullptr)
             {
+                av_free(fileStreamBuffer);
                 hr = E_OUTOFMEMORY;
             }
         }
@@ -1404,11 +1405,6 @@ namespace winrt::FFmpegInteropX::implementation
         if (m_pReader != nullptr)
         {
             m_pReader.reset();;
-        }
-
-        if (fileStreamBuffer)
-        {
-            av_freep(fileStreamBuffer);
         }
 
         for (auto &x : subtitleStreams)

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -54,7 +54,7 @@ namespace winrt::FFmpegInteropX::implementation
 
         if (!isRegistered)
         {
-            auto guard = std::lock_guard(isRegisteredMutex);
+            std::lock_guard lock(isRegisteredMutex);
             if (!isRegistered)
             {
                 LanguageTagConverter::Initialize();
@@ -253,7 +253,7 @@ namespace winrt::FFmpegInteropX::implementation
     void FFmpegMediaSource::OnPresentationModeChanged(MediaPlaybackTimedMetadataTrackList const& sender, TimedMetadataPresentationModeChangedEventArgs const& args)
     {
         UNREFERENCED_PARAMETER(sender);
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         int index = 0;
         for (auto &stream : subtitleStreams)
         {
@@ -276,7 +276,7 @@ namespace winrt::FFmpegInteropX::implementation
     void FFmpegMediaSource::OnAudioTracksChanged(MediaPlaybackItem const& sender, IVectorChangedEventArgs const& args)
     {
         UNREFERENCED_PARAMETER(args);
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (sender.AudioTracks().Size() == AudioStreams().Size())
         {
             for (unsigned int i = 0; i < AudioStreams().Size(); i++)
@@ -1015,7 +1015,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     void FFmpegMediaSource::SetSubtitleDelay(TimeSpan const& delay)
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         try
         {
             for (auto &subtitleStream : subtitleStreams)
@@ -1032,7 +1032,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     void FFmpegMediaSource::SetFFmpegAudioFilters(hstring const& audioFilters)
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (currentAudioStream)
         {
             currentAudioStream->SetFilters(audioFilters);
@@ -1042,7 +1042,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     void FFmpegMediaSource::SetFFmpegVideoFilters(hstring const& videoEffects)
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (currentVideoStream)
         {
             currentVideoStream->SetFilters(videoEffects);
@@ -1053,7 +1053,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     void FFmpegMediaSource::DisableAudioEffects()
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (currentAudioStream)
         {
             currentAudioStream->DisableFilters();
@@ -1063,7 +1063,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     void FFmpegMediaSource::DisableVideoEffects()
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (currentVideoStream)
         {
             currentVideoStream->DisableFilters();
@@ -1151,7 +1151,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     MediaPlaybackItem FFmpegMediaSource::CreateMediaPlaybackItem()
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (this->config->IsFrameGrabber || playbackItem != nullptr) throw_hresult(E_UNEXPECTED);
         playbackItem = MediaPlaybackItem(CreateMediaSource());
         InitializePlaybackItem(playbackItem);
@@ -1160,7 +1160,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     MediaPlaybackItem FFmpegMediaSource::CreateMediaPlaybackItem(TimeSpan const& startTime)
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (this->config->IsFrameGrabber || playbackItem != nullptr) throw_hresult(E_UNEXPECTED);
         playbackItem = MediaPlaybackItem(CreateMediaSource(), startTime);
         InitializePlaybackItem(playbackItem);
@@ -1169,7 +1169,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     MediaPlaybackItem FFmpegMediaSource::CreateMediaPlaybackItem(TimeSpan const& startTime, TimeSpan const& durationLimit)
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (this->config->IsFrameGrabber || playbackItem != nullptr) throw_hresult(E_UNEXPECTED);
         playbackItem = MediaPlaybackItem(CreateMediaSource(), startTime, durationLimit);
         InitializePlaybackItem(playbackItem);
@@ -1231,7 +1231,7 @@ namespace winrt::FFmpegInteropX::implementation
         }
 
 
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (SubtitleDelay().count() != externalSubsParser->SubtitleDelay().count())
         {
             externalSubsParser->SetSubtitleDelay(SubtitleDelay());
@@ -1367,7 +1367,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     void FFmpegMediaSource::PlaybackSession(MediaPlaybackSession const& value)
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (session)
         {
             session.PositionChanged(sessionPositionEvent);
@@ -1381,7 +1381,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     void FFmpegMediaSource::Close()
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (mss)
         {
             mss.Starting(startingRequestedToken);
@@ -1679,7 +1679,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     void FFmpegMediaSource::OnStarting(MediaStreamSource const& sender, MediaStreamSourceStartingEventArgs const& args)
     {
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         MediaStreamSourceStartingRequest request = args.Request();
 
         if (isFirstSeek && avHardwareContext)
@@ -1742,7 +1742,7 @@ namespace winrt::FFmpegInteropX::implementation
     void FFmpegMediaSource::OnSampleRequested(winrt::Windows::Media::Core::MediaStreamSource const& sender, winrt::Windows::Media::Core::MediaStreamSourceSampleRequestedEventArgs const& args)
     {
         UNREFERENCED_PARAMETER(sender);
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         if (mss != nullptr)
         {
             if (currentAudioStream && args.Request().StreamDescriptor() == currentAudioStream->StreamDescriptor())
@@ -1851,7 +1851,7 @@ namespace winrt::FFmpegInteropX::implementation
     void FFmpegMediaSource::OnSwitchStreamsRequested(MediaStreamSource const& sender, MediaStreamSourceSwitchStreamsRequestedEventArgs const& args)
     {
         UNREFERENCED_PARAMETER(sender);
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
 
         if (currentAudioStream && args.Request().OldStreamDescriptor() == currentAudioStream->StreamDescriptor())
         {
@@ -2076,7 +2076,7 @@ namespace winrt::FFmpegInteropX::implementation
     {
         UNREFERENCED_PARAMETER(sender);
         UNREFERENCED_PARAMETER(args);
-        auto guard = std::lock_guard(mutex);
+        std::lock_guard lock(mutex);
         lastPosition = currentPosition;
         currentPosition = sender.Position();
     }

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -236,7 +236,7 @@ namespace winrt::FFmpegInteropX::implementation
 
         std::shared_ptr<MediaMetadata> metadata = { nullptr };
 
-        std::recursive_mutex mutexGuard;
+        winrt::slim_mutex mutex;
         CoreDispatcher dispatcher = { nullptr };
         MediaPlaybackSession session = { nullptr };
         winrt::event_token sessionPositionEvent{};

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -245,7 +245,6 @@ namespace winrt::FFmpegInteropX::implementation
         hstring audioCodecName{};
         TimeSpan mediaDuration{};
         TimeSpan subtitleDelay{};
-        unsigned char* fileStreamBuffer = NULL;
         bool isFirstSeek;
         AVBufferRef* avHardwareContext = NULL;
         AVBufferRef* avHardwareContextDefault = NULL;

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -236,7 +236,7 @@ namespace winrt::FFmpegInteropX::implementation
 
         std::shared_ptr<MediaMetadata> metadata = { nullptr };
 
-        winrt::slim_mutex mutex;
+        std::recursive_mutex mutex;
         CoreDispatcher dispatcher = { nullptr };
         MediaPlaybackSession session = { nullptr };
         winrt::event_token sessionPositionEvent{};

--- a/Source/FrameGrabber.h
+++ b/Source/FrameGrabber.h
@@ -116,12 +116,7 @@ namespace winrt::FFmpegInteropX::implementation
                     throw_hresult(E_INVALIDARG);
                 }
 
-                // Query the IBufferByteAccess interface.  
-                winrt::com_ptr<IBufferByteAccess> bufferByteAccess;
-                targetBuffer.as(IID_PPV_ARGS(&bufferByteAccess));
-
-                // Retrieve the buffer data.  
-                bufferByteAccess->Buffer(&pixels);
+                pixels = targetBuffer.data();
             }
             sampleProvider->TargetBuffer = pixels;
         }

--- a/Source/NativeBuffer.h
+++ b/Source/NativeBuffer.h
@@ -9,8 +9,6 @@ namespace NativeBuffer
 
     struct NativeBuffer : winrt::implements<NativeBuffer, winrt::Windows::Storage::Streams::IBuffer, IBufferByteAccess>
     {
-        //InspectableClass("NativeBuffer.NativeBuffer", BaseTrust)
-
     public:
         virtual ~NativeBuffer()
         {

--- a/Source/SubtitleProvider.h
+++ b/Source/SubtitleProvider.h
@@ -182,7 +182,7 @@ namespace FFmpegInteropX
 
         void SetSubtitleDelay(TimeSpan const& delay)
         {
-            auto guard = std::lock_guard(mutex);
+            std::lock_guard lock(mutex);
             newDelay = delay;
             try
             {
@@ -228,7 +228,7 @@ namespace FFmpegInteropX
 
         void AddCue(IMediaCue const& cue)
         {
-            auto guard = std::lock_guard(mutex);
+            std::lock_guard lock(mutex);
             try
             {
                 if (Metadata::ApiInformation::IsApiContractPresent(L"Windows.Phone.PhoneContract", 1, 0))
@@ -292,7 +292,7 @@ namespace FFmpegInteropX
         void OnRefCueEntered(TimedMetadataTrack const& sender, MediaCueEventArgs const& args)
         {
             UNREFERENCED_PARAMETER(sender);
-            auto guard = std::lock_guard(mutex);
+            std::lock_guard lock(mutex);
             try {
                 //remove all cues from subtitle track
                 while (SubtitleTrack.Cues().Size() > 0)
@@ -311,7 +311,7 @@ namespace FFmpegInteropX
         void OnCueEntered(TimedMetadataTrack const& sender, MediaCueEventArgs const& args)
         {
             UNREFERENCED_PARAMETER(sender);
-            auto guard = std::lock_guard(mutex);
+            std::lock_guard lock(mutex);
             try
             {
                 //cleanup old cues to free memory
@@ -363,7 +363,7 @@ namespace FFmpegInteropX
         {
             UNREFERENCED_PARAMETER(sender);
             UNREFERENCED_PARAMETER(args);
-            auto guard = std::lock_guard(mutex);
+            std::lock_guard lock(mutex);
 
             try
             {
@@ -524,7 +524,7 @@ namespace FFmpegInteropX
             {
                 CompressedSampleProvider::Flush();
 
-                auto guard = std::lock_guard(mutex);
+                std::lock_guard lock(mutex);
 
                 if (dispatcher)
                 {

--- a/Source/SubtitleProvider.h
+++ b/Source/SubtitleProvider.h
@@ -182,7 +182,7 @@ namespace FFmpegInteropX
 
         void SetSubtitleDelay(TimeSpan const& delay)
         {
-            mutex.lock();
+            auto guard = std::lock_guard(mutex);
             newDelay = delay;
             try
             {
@@ -190,9 +190,7 @@ namespace FFmpegInteropX
             }
             catch (...)
             {
-
             }
-            mutex.unlock();
         }
 
         int parseInt(std::wstring const& str)
@@ -230,7 +228,7 @@ namespace FFmpegInteropX
 
         void AddCue(IMediaCue const& cue)
         {
-            mutex.lock();
+            auto guard = std::lock_guard(mutex);
             try
             {
                 if (Metadata::ApiInformation::IsApiContractPresent(L"Windows.Phone.PhoneContract", 1, 0))
@@ -271,7 +269,6 @@ namespace FFmpegInteropX
             {
                 OutputDebugString(L"Failed to add subtitle cue.");
             }
-            mutex.unlock();
         }
 
         void DispatchCueToTrack(IMediaCue const& cue)
@@ -295,7 +292,7 @@ namespace FFmpegInteropX
         void OnRefCueEntered(TimedMetadataTrack const& sender, MediaCueEventArgs const& args)
         {
             UNREFERENCED_PARAMETER(sender);
-            mutex.lock();
+            auto guard = std::lock_guard(mutex);
             try {
                 //remove all cues from subtitle track
                 while (SubtitleTrack.Cues().Size() > 0)
@@ -309,13 +306,12 @@ namespace FFmpegInteropX
             catch (...)
             {
             }
-            mutex.unlock();
         }
 
         void OnCueEntered(TimedMetadataTrack const& sender, MediaCueEventArgs const& args)
         {
             UNREFERENCED_PARAMETER(sender);
-            mutex.lock();
+            auto guard = std::lock_guard(mutex);
             try
             {
                 //cleanup old cues to free memory
@@ -337,7 +333,6 @@ namespace FFmpegInteropX
             {
                 OutputDebugString(L"Failed to cleanup old cues.");
             }
-            mutex.unlock();
         }
 
         void TriggerUpdateCues()
@@ -368,7 +363,7 @@ namespace FFmpegInteropX
         {
             UNREFERENCED_PARAMETER(sender);
             UNREFERENCED_PARAMETER(args);
-            mutex.lock();
+            auto guard = std::lock_guard(mutex);
 
             try
             {
@@ -418,8 +413,6 @@ namespace FFmpegInteropX
             {
                 timer.Stop();
             }
-
-            mutex.unlock();
         }
 
         void UpdateCuePositions()
@@ -531,7 +524,7 @@ namespace FFmpegInteropX
             {
                 CompressedSampleProvider::Flush();
 
-                mutex.lock();
+                auto guard = std::lock_guard(mutex);
 
                 if (dispatcher)
                 {
@@ -542,8 +535,6 @@ namespace FFmpegInteropX
                 {
                     ClearSubtitles();
                 }
-
-                mutex.unlock();
             }
         }
 

--- a/Source/SubtitleProviderBitmap.h
+++ b/Source/SubtitleProviderBitmap.h
@@ -8,11 +8,6 @@ namespace FFmpegInteropX
     using namespace winrt::Windows::Graphics::Imaging;
     using namespace winrt::Windows::Media::Core;
 
-    struct __declspec(uuid("5b0d3235-4dba-4d44-865e-8f1d0e4fd04d")) __declspec(novtable) IMemoryBufferByteAccess : ::IUnknown
-    {
-        virtual HRESULT __stdcall GetBuffer(uint8_t** value, uint32_t* capacity) = 0;
-    };
-
     class SubtitleProviderBitmap : public SubtitleProvider
     {
 
@@ -84,15 +79,7 @@ namespace FFmpegInteropX
                     {
                         auto buffer = bitmap.LockBuffer(BitmapBufferAccessMode::Write);
                         auto reference = buffer.CreateReference();
-
-                        // Query the IBufferByteAccess interface.  
-                        winrt::com_ptr<IMemoryBufferByteAccess> bufferByteAccess;
-                        reference.as(IID_PPV_ARGS(&bufferByteAccess));
-
-                        // Retrieve the buffer data.  
-                        BYTE* pixels = nullptr;
-                        unsigned int capacity;
-                        bufferByteAccess->GetBuffer(&pixels, &capacity);
+                        BYTE* pixels = reference.data();
 
                         auto plane = buffer.GetPlaneDescription(0);
 

--- a/Source/VideoFrame.h
+++ b/Source/VideoFrame.h
@@ -37,13 +37,8 @@ namespace winrt::FFmpegInteropX::implementation
         {
             auto strong = get_strong();
 
-            // Query the IBufferByteAccess interface.  
-            winrt::com_ptr<IBufferByteAccess> bufferByteAccess;
-            (pixelData).as(IID_PPV_ARGS(&bufferByteAccess));
-
             // Retrieve the buffer data.  
-            byte* pixels = nullptr;
-            bufferByteAccess->Buffer(&pixels);
+            byte* pixels = pixelData.data();
             auto length = pixelData.Length();
 
             auto encoderValue = co_await winrt::Windows::Graphics::Imaging::BitmapEncoder::CreateAsync(encoderGuid, stream);


### PR DESCRIPTION
Also using .data() to get IBuffer content instead of manual COM interop