### PR TITLE
Fix FFmpegOptions parsing and enable local network access

### DIFF
--- a/Samples/MediaPlayerCPP/MainPage.xaml.cpp
+++ b/Samples/MediaPlayerCPP/MainPage.xaml.cpp
@@ -175,11 +175,16 @@ void MainPage::URIBoxKeyUp(Platform::Object^ sender, Windows::UI::Xaml::Input::K
 
 task<void> MainPage::OpenUriStream(Platform::String^ uri)
 {
-    // Set FFmpeg specific options. List of options can be found in https://www.ffmpeg.org/ffmpeg-protocols.html
-
+    // Set FFmpeg specific options:
+    // https://www.ffmpeg.org/ffmpeg-protocols.html
+    // https://www.ffmpeg.org/ffmpeg-formats.html
+    // 
+    // If format cannot be detected, try to increase probesize, max_probe_packets and analyzeduration!
+    
     // Below are some sample options that you can set to configure RTSP streaming
-    // Config->FFmpegOptions->Insert("rtsp_flags", "prefer_tcp");
-    // Config->FFmpegOptions->Insert("stimeout", 100000);
+    //Config->FFmpegOptions->Insert("rtsp_flags", "prefer_tcp");
+    Config->FFmpegOptions->Insert("stimeout", 1000000);
+    Config->FFmpegOptions->Insert("timeout", 1000000);
 
     // Instantiate FFmpegMediaSource using the URI
     mediaPlayer->Source = nullptr;

--- a/Samples/MediaPlayerCPP/Package.appxmanifest
+++ b/Samples/MediaPlayerCPP/Package.appxmanifest
@@ -44,5 +44,6 @@
   <Capabilities>
     <Capability Name="internetClient" />
     <uap3:Capability Name="backgroundMediaPlayback" />
+    <Capability Name="privateNetworkClientServer"/>
   </Capabilities>
 </Package>

--- a/Samples/MediaPlayerCS/MainPage.xaml.cs
+++ b/Samples/MediaPlayerCS/MainPage.xaml.cs
@@ -227,11 +227,16 @@ namespace MediaPlayerCS
 
                 try
                 {
-                    // Set FFmpeg specific options. List of options can be found in https://www.ffmpeg.org/ffmpeg-protocols.html
+                    // Set FFmpeg specific options:
+                    // https://www.ffmpeg.org/ffmpeg-protocols.html
+                    // https://www.ffmpeg.org/ffmpeg-formats.html
+
+                    // If format cannot be detected, try to increase probesize, max_probe_packets and analyzeduration!
 
                     // Below are some sample options that you can set to configure RTSP streaming
                     // Config.FFmpegOptions.Add("rtsp_flags", "prefer_tcp");
-                    // Config.FFmpegOptions.Add("stimeout", 100000);
+                    Config.FFmpegOptions.Add("stimeout", 1000000);
+                    Config.FFmpegOptions.Add("timeout", 1000000);
 
                     // Instantiate FFmpegMediaSource using the URI
                     mediaPlayer.Source = null;

--- a/Samples/MediaPlayerCS/Package.appxmanifest
+++ b/Samples/MediaPlayerCS/Package.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"  xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" IgnorableNamespaces="uap mp uap3">
   <Identity Name="5388ef25-5c75-440f-a383-14d03f338feb" Publisher="CN=FFmpegInterop" Version="1.0.2.0" />
   <mp:PhoneIdentity PhoneProductId="5388ef25-5c75-440f-a383-14d03f338feb" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -24,5 +24,7 @@
   </Applications>
   <Capabilities>
     <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer"/>
+    <uap3:Capability Name="backgroundMediaPlayback"/>
   </Capabilities>
 </Package>

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -1659,13 +1659,12 @@ namespace winrt::FFmpegInteropX::implementation
             while (options.HasCurrent())
             {
                 auto key = StringUtils::PlatformStringToUtf8String(options.Current().Key());
-                auto stringValue = options.Current().Value().try_as<IStringable>();
-                if (stringValue)
+                hstring value = StringUtils::ToString(options.Current().Value());
+                if (!value.empty())
                 {
-                    auto value = StringUtils::PlatformStringToUtf8String(stringValue.ToString());
-
                     // Add key and value pair entry
-                    if (av_dict_set(&avDict, key.c_str(), value.c_str(), 0) < 0)
+                    auto valCstr = StringUtils::PlatformStringToUtf8String(value);
+                    if (av_dict_set(&avDict, key.c_str(), valCstr.c_str(), 0) < 0)
                     {
                         hr = E_INVALIDARG;
                         break;

--- a/Source/StringUtils.h
+++ b/Source/StringUtils.h
@@ -44,5 +44,34 @@ namespace FFmpegInteropX
             return std::string("");
         }
 
+        inline static winrt::hstring ToString(winrt::Windows::Foundation::IInspectable inspectable)
+        {
+            auto valHstring = inspectable.try_as<winrt::hstring>();
+            if (valHstring.has_value())
+            {
+                return valHstring.value();
+            }
+            auto valI32 = inspectable.try_as<INT32>();
+            if (valI32.has_value())
+            {
+                return winrt::to_hstring(valI32.value());
+            }
+            auto valI64 = inspectable.try_as<INT64>();
+            if (valI64.has_value())
+            {
+                return winrt::to_hstring(valI64.value());
+            }
+            auto valf = inspectable.try_as<FLOAT>();
+            if (valf.has_value())
+            {
+                return winrt::to_hstring(valf.value());
+            }
+            auto vald = inspectable.try_as<DOUBLE>();
+            if (vald.has_value())
+            {
+                return winrt::to_hstring(vald.value());
+            }
+            return L"";
+        }
     };
 }

--- a/Source/UncompressedSampleProvider.cpp
+++ b/Source/UncompressedSampleProvider.cpp
@@ -74,6 +74,8 @@ HRESULT UncompressedSampleProvider::CreateNextSampleBuffer(IBuffer* pBuffer, int
 
         if (!SUCCEEDED(hr) && errorCount++ < m_config.SkipErrors())
         {
+            DebugMessage(L"Decode error.\n");
+
             // unref any buffers in old frame
             av_frame_unref(avFrame);
 


### PR DESCRIPTION
This should allow for receiving UDP streams from different PC as in #280.

If format cannot be detected, try to increase probesize, max_probe_packets and analyzeduration in FFmpegOptions!
https://www.ffmpeg.org/ffmpeg-formats.html

Also check e.g. fifo_size for UDP:
http://www.ffmpeg.org/ffmpeg-protocols.html#udp