### PR TITLE
Fix first-chance exception when getting metadata

### DIFF
--- a/Source/MediaMetadata.h
+++ b/Source/MediaMetadata.h
@@ -33,8 +33,12 @@ public:
                         auto key = StringUtils::Utf8ToPlatformString(entry->key);
                         auto value = StringUtils::Utf8ToPlatformString(entry->value);
 
-                        auto valueList = entriesLocal.TryLookup(key);
-                        if (!valueList)
+                        IVector<winrt::hstring> valueList;
+                        if (entriesLocal.HasKey(key))
+                        {
+                            valueList = entriesLocal.Lookup(key);
+                        }
+                        else
                         {
                             valueList = winrt::single_threaded_observable_vector<winrt::hstring>();
                             entriesLocal.Insert(key, valueList);


### PR DESCRIPTION
The TryLookup method of IMap is internally implemented like `try { return Lookup(); } catch { return default; }`. Since we used it for retrieving MediaMetadata, it caused first-chance exceptions for every new tag. Pretty bad for debugging, so I removed its use.