### PR TITLE
Fix first-chance exception in AttachedFileHelper

### DIFF
--- a/Source/AttachedFileHelper.h
+++ b/Source/AttachedFileHelper.h
@@ -41,10 +41,9 @@ public:
     winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::StorageFile> ExtractFileAsync(std::shared_ptr<AttachedFile> attachment)
     {
         StorageFile file = { nullptr };
-        auto result = extractedFiles.TryLookup(attachment->Name());
-        if (result != nullptr)
+        if (extractedFiles.HasKey(attachment->Name()))
         {
-            file = result;
+            file = extractedFiles.Lookup(attachment->Name());
         }
         else
         {


### PR DESCRIPTION
I also used TryLookup in AttachedFileHelper. This removes it to prevent first-chance exceptions popping up. I also checked that there are no other uses of this method.