### PR TITLE
Call Close when mss is closed

### DIFF
--- a/Samples/MediaPlayerWinUI/MainPage.xaml.cs
+++ b/Samples/MediaPlayerWinUI/MainPage.xaml.cs
@@ -62,7 +62,6 @@ namespace MediaPlayerWinUI
             Config = new MediaSourceConfig();
 
             this.InitializeComponent();
-
             // Show the control panel on startup so user can start opening media
             Splitter.IsPaneOpen = true;
             AutoDetect.IsOn = true;

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -685,6 +685,7 @@ namespace winrt::FFmpegInteropX::implementation
                 startingRequestedToken = mss.Starting({ get_weak(), &FFmpegMediaSource::OnStarting });
                 sampleRequestedToken = mss.SampleRequested({ get_weak(), &FFmpegMediaSource::OnSampleRequested });
                 switchStreamRequestedToken = mss.SwitchStreamsRequested({ get_weak(), &FFmpegMediaSource::OnSwitchStreamsRequested });
+                closeToken = mss.Closed({ get_weak(), &FFmpegMediaSource::MediaStreamSourceClosed });
             }
         }
 
@@ -1378,6 +1379,7 @@ namespace winrt::FFmpegInteropX::implementation
             mss.Starting(startingRequestedToken);
             mss.SampleRequested(sampleRequestedToken);
             mss.SwitchStreamsRequested(switchStreamRequestedToken);
+            mss.Closed(closeToken);
             mss = nullptr;
         }
 
@@ -1662,6 +1664,11 @@ namespace winrt::FFmpegInteropX::implementation
         }
 
         return hr;
+    }
+
+    void FFmpegMediaSource::MediaStreamSourceClosed(MediaStreamSource const& sender, MediaStreamSourceClosedEventArgs const& args)
+    {
+        Close();
     }
 
     void FFmpegMediaSource::OnStarting(MediaStreamSource const& sender, MediaStreamSourceStartingEventArgs const& args)

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -159,6 +159,7 @@ namespace winrt::FFmpegInteropX::implementation
         std::shared_ptr<MediaSampleProvider> CreateAudioSampleProvider(AVStream* avStream, AVCodecContext* avCodecCtx, int index);
         std::shared_ptr<MediaSampleProvider> CreateVideoSampleProvider(AVStream* avStream, AVCodecContext* avCodecCtx, int index);
         HRESULT ParseOptions(PropertySet const& ffmpegOptions);
+        void MediaStreamSourceClosed(MediaStreamSource const& sender, MediaStreamSourceClosedEventArgs const& args);
         void OnStarting(MediaStreamSource const& sender, MediaStreamSourceStartingEventArgs const& args);
         void OnSampleRequested(MediaStreamSource const& sender, MediaStreamSourceSampleRequestedEventArgs const& args);
         void CheckVideoDeviceChanged();
@@ -199,14 +200,14 @@ namespace winrt::FFmpegInteropX::implementation
         ByteOrderMark streamByteOrderMark;
         winrt::com_ptr<MediaSourceConfig> config = { nullptr };
 
-
     private:
-
 
         MediaStreamSource mss = { nullptr };
         winrt::event_token startingRequestedToken{};
         winrt::event_token sampleRequestedToken{};
         winrt::event_token switchStreamRequestedToken{};
+        winrt::event_token closeToken{};
+
         MediaPlaybackItem playbackItem = { nullptr };
         IVector<FFmpegInteropX::AudioStreamInfo> audioStrInfos = { nullptr };
         IVector<FFmpegInteropX::SubtitleStreamInfo> subtitleStrInfos = { nullptr };
@@ -224,7 +225,6 @@ namespace winrt::FFmpegInteropX::implementation
 
         winrt::event_token audioTracksChangedToken{};
         winrt::event_token subtitlePresentationModeChangedToken{};
-
 
         IVectorView<FFmpegInteropX::VideoStreamInfo> videoStreamInfos = { nullptr };
         IVectorView<FFmpegInteropX::AudioStreamInfo> audioStreamInfos = { nullptr };


### PR DESCRIPTION
There are various instances in which media stream source closed event gets called:
1. When MediaSource.Dispose is called
2. When GC swings by
3. By the MF itself

This makes us clean up the ffmpeg media source when the closed event gets called. This should make it easier to manage memory, instead of manually calling Dispose on ffmpeg media source.