### PR TITLE
Fix crash when assigning a new filter after playback is already finished

### DIFF
--- a/Source/AudioFilter.h
+++ b/Source/AudioFilter.h
@@ -219,4 +219,9 @@ public:
 
         return hr;
     }
+
+    bool IsInitialized() override
+    {
+        return isInitialized;
+    }
 };

--- a/Source/IAvEffect.h
+++ b/Source/IAvEffect.h
@@ -12,4 +12,6 @@ public:
     virtual HRESULT AddFrame(AVFrame* frame) = 0;
 
     virtual HRESULT GetFrame(AVFrame* frame) = 0;
+
+    virtual bool IsInitialized() = 0;
 };

--- a/Source/UncompressedFrameProvider.h
+++ b/Source/UncompressedFrameProvider.h
@@ -112,12 +112,19 @@ public:
                 }
                 else if (hr == AVERROR_EOF)
                 {
-                    // feed NULL packet to filter to enter draining mode on EOF
-                    hr = filter->AddFrame(NULL);
-                    if (FAILED(hr))
+                    if (filter->IsInitialized())
                     {
-                        // add frame failed. clear filter to prevent crashes.
-                        filter = nullptr;
+                        // feed NULL packet to filter to enter draining mode on EOF
+                        hr = filter->AddFrame(NULL);
+                        if (FAILED(hr))
+                        {
+                            // add frame failed. clear filter to prevent crashes.
+                            filter = nullptr;
+                        }
+                    }
+                    else
+                    {
+                        // we cannot initialize from NULL frame
                     }
                 }
             }

--- a/Source/VideoFilter.h
+++ b/Source/VideoFilter.h
@@ -228,6 +228,11 @@ public:
         return hr;
     }
 
+    bool IsInitialized() override
+    {
+        return isInitialized;
+    }
+
 public:
     virtual ~VideoFilter()
     {


### PR DESCRIPTION
While testing the loop filter for #304, I observed an access violation when assigning a new filter when file is already EOF. We send a NULL frame to enter draining mode, but because the filter is not yet initialized, it tries to initialize from NULL frame and crashes.