### PR TITLE
Fix playback not working after EOF with filters

### DIFF
--- a/Source/UncompressedSampleProvider.cpp
+++ b/Source/UncompressedSampleProvider.cpp
@@ -203,6 +203,8 @@ void UncompressedSampleProvider::Flush()
 {
     MediaSampleProvider::Flush();
 
+    frameProvider->Flush();
+
     // after seek we need to get first packet pts again
     hasNextFramePts = false;
 }

--- a/Source/UncompressedSampleProvider.cpp
+++ b/Source/UncompressedSampleProvider.cpp
@@ -203,8 +203,6 @@ void UncompressedSampleProvider::Flush()
 {
     MediaSampleProvider::Flush();
 
-    frameProvider->Flush();
-
     // after seek we need to get first packet pts again
     hasNextFramePts = false;
 }


### PR DESCRIPTION
It was reported in #304 that seeking and playback does not work after EOF, when filters were applied. The reason is that we drain the filters on EOF. After they are drained, they always return EOF. There is no flush method for filters, which is what brings normal codecs back working after EOF. Instead, we need to feed a new packet to the filter, to recover it from EOF mode.