### PR TITLE
Enable grabbing of files as png with alpha channel

### DIFF
--- a/Samples/MediaPlayerCPP/MainPage.xaml.cpp
+++ b/Samples/MediaPlayerCPP/MainPage.xaml.cpp
@@ -240,15 +240,27 @@ task<void> MainPage::ExtractFrame()
         filePicker->SuggestedStartLocation = PickerLocationId::VideosLibrary;
         filePicker->DefaultFileExtension = ".jpg";
         filePicker->FileTypeChoices->Insert("Jpeg file", ref new Platform::Collections::Vector<String^>(1, ".jpg"));
+        filePicker->FileTypeChoices->Insert("Png file", ref new Platform::Collections::Vector<String^>(1, ".png"));
+        filePicker->FileTypeChoices->Insert("Bmp file", ref new Platform::Collections::Vector<String^>(1, ".bmp"));
 
         // Show file picker so user can select a file
         auto file = co_await filePicker->PickSaveFileAsync();
         if (file != nullptr)
         {
-            auto stream = co_await file->OpenAsync(FileAccessMode::ReadWrite);
-            // encode frame as jpeg file
-            co_await frame->EncodeAsJpegAsync(stream);
-            stream = nullptr;
+            auto outputStream = co_await file->OpenAsync(FileAccessMode::ReadWrite);
+            if (file->FileType == ".jpg")
+            {
+                co_await frame->EncodeAsJpegAsync(outputStream);
+            }
+            else if (file->FileType == ".png")
+            {
+                co_await frame->EncodeAsPngAsync(outputStream);
+            }
+            else
+            {
+                co_await frame->EncodeAsBmpAsync(outputStream);
+            }
+            outputStream = nullptr;
 
             // launch file after creation
             auto launched = co_await Windows::System::Launcher::LaunchFileAsync(file);

--- a/Samples/MediaPlayerCS/MainPage.xaml.cs
+++ b/Samples/MediaPlayerCS/MainPage.xaml.cs
@@ -288,12 +288,25 @@ namespace MediaPlayerCS
                     filePicker.SuggestedStartLocation = PickerLocationId.VideosLibrary;
                     filePicker.DefaultFileExtension = ".jpg";
                     filePicker.FileTypeChoices["Jpeg file"] = new[] { ".jpg" }.ToList();
+                    filePicker.FileTypeChoices["Png file"] = new[] { ".png" }.ToList();
+                    filePicker.FileTypeChoices["Bmp file"] = new[] { ".bmp" }.ToList();
 
                     var file = await filePicker.PickSaveFileAsync();
                     if (file != null)
                     {
                         var outputStream = await file.OpenAsync(FileAccessMode.ReadWrite);
+                        if (file.FileType == ".jpg")
+                        {
                         await frame.EncodeAsJpegAsync(outputStream);
+                        }
+                        else if(file.FileType == ".png")
+                        {
+                            await frame.EncodeAsPngAsync(outputStream);
+                        }
+                        else
+                        {
+                            await frame.EncodeAsBmpAsync(outputStream);
+                        }
                         outputStream.Dispose();
                         bool launched = await Windows.System.Launcher.LaunchFileAsync(file, new LauncherOptions() { DisplayApplicationPicker = false });
                         if (!launched)

--- a/Samples/MediaPlayerWinUI/MainPage.xaml.cs
+++ b/Samples/MediaPlayerWinUI/MainPage.xaml.cs
@@ -283,12 +283,25 @@ namespace MediaPlayerWinUI
                     filePicker.SuggestedStartLocation = PickerLocationId.VideosLibrary;
                     filePicker.DefaultFileExtension = ".jpg";
                     filePicker.FileTypeChoices["Jpeg file"] = new[] { ".jpg" }.ToList();
+                    filePicker.FileTypeChoices["Png file"] = new[] { ".png" }.ToList();
+                    filePicker.FileTypeChoices["Bmp file"] = new[] { ".bmp" }.ToList();
 
                     var file = await filePicker.PickSaveFileAsync();
                     if (file != null)
                     {
                         var outputStream = await file.OpenAsync(FileAccessMode.ReadWrite);
-                        await frame.EncodeAsJpegAsync(outputStream);
+                        if (file.FileType == ".jpg")
+                        {
+                            await frame.EncodeAsJpegAsync(outputStream);
+                        }
+                        else if (file.FileType == ".png")
+                        {
+                            await frame.EncodeAsPngAsync(outputStream);
+                        }
+                        else
+                        {
+                            await frame.EncodeAsBmpAsync(outputStream);
+                        }
                         outputStream.Dispose();
                         bool launched = await Windows.System.Launcher.LaunchFileAsync(file, new LauncherOptions() { DisplayApplicationPicker = false });
                         if (!launched)

--- a/Source/VideoFrame.h
+++ b/Source/VideoFrame.h
@@ -54,7 +54,7 @@ namespace winrt::FFmpegInteropX::implementation
 
             encoderValue.SetPixelData(
                 BitmapPixelFormat::Bgra8,
-                BitmapAlphaMode::Ignore,
+                BitmapAlphaMode::Straight,
                 pixelWidth,
                 pixelHeight,
                 72,


### PR DESCRIPTION
The FrameGrabber will now correctly transport the alpha channel to encoders. Only the PNG encoder supports alpha. Samples were updated to allow output file format selection.