### PR TITLE
Fix NuGet references to allow build and publish with only FFmpegInteropX package

### DIFF
--- a/Build/FFmpegInteropX.nuspec
+++ b/Build/FFmpegInteropX.nuspec
@@ -9,11 +9,14 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <dependencies>
-      <group>
-          <dependency id="FFmpegInteropX.FFmpegUWP" version="5.0.0" />
+      <group targetFramework="uap10.0">
+        <dependency id="FFmpegInteropX.FFmpegUWP" version="5.1.100" />
+        <dependency id="Win2D.uwp" version="1.26.0" />
       </group>
-      <group targetFramework="uap10.0" />
-      <group targetFramework="net6.0-windows10.0.19041.0" />
+      <group targetFramework="net6.0-windows10.0.19041.0">
+        <dependency id="FFmpegInteropX.FFmpegUWP" version="5.1.100" />
+        <dependency id="Win2D.uwp" version="1.26.0" />
+      </group>
     </dependencies>
     <repository type="git" url="$repositoryUrl$" branch="$repositoryBranch$" commit="$repositoryCommit$" />
   </metadata>


### PR DESCRIPTION
This solves #315 

It is still recommended though to manually add FFmpegInteropX.FFmpegUWP as a primary NuGet reference, since only then you are able to manually select and update the FFmpegUWP version. We do not ship new FFmpegInteropX every time FFmpegUWP has changed.