### PR TITLE
Auto extend media duration if stream contains additional data

### DIFF
--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -171,7 +171,7 @@ namespace winrt::FFmpegInteropX::implementation
         void OnPresentationModeChanged(MediaPlaybackTimedMetadataTrackList  const& sender, TimedMetadataPresentationModeChangedEventArgs  const& args);
         void InitializePlaybackItem(MediaPlaybackItem  const& playbackitem);
         bool CheckUseHardwareAcceleration(AVCodecContext* avCodecCtx, HardwareAccelerationStatus const& status, HardwareDecoderStatus& hardwareDecoderStatus, int maxProfile, int maxLevel);
-
+        void CheckExtendDuration(MediaStreamSample sample);
 
     public://internal:
         static winrt::com_ptr<FFmpegMediaSource> CreateFromStream(IRandomAccessStream const& stream, winrt::com_ptr<MediaSourceConfig> const& config, DispatcherQueue  const& dispatcher);
@@ -245,6 +245,8 @@ namespace winrt::FFmpegInteropX::implementation
 
         bool isFirstSeek;
         bool isFirstSeekAfterStreamSwitch = false;
+
+        int lastDurationExtension = 0;
 
         TimeSpan currentPosition{ 0 };
         TimeSpan lastPosition{ 0 };

--- a/Source/MediaSourceConfig.h
+++ b/Source/MediaSourceConfig.h
@@ -183,6 +183,9 @@ namespace winrt::FFmpegInteropX::implementation
         ///<summary>Downmix multi-channel audio streams to stereo format.</summary>
         PROPERTY(DownmixAudioStreamsToStereo, bool, false);
 
+        ///<summary>Automatically extend the duration of the MediaStreamSource, if the file unexpectedly contains additional data.</summary>
+        PROPERTY(AutoExtendDuration, bool, true);
+
     public:
         //internal:
         bool IsFrameGrabber;


### PR DESCRIPTION
Sometimes there are files where the duration is not detected correctly, or metadata contains wrong duration tag. Or a filter extends the duration of the file. If the MediaStreamSource delivers more samples than expected by MediaPlayer, then the MediaPlayer will fast forward through all samples until reaching EOF. This is a bit weird and usually not what you want.

This PR detects if a sample has a higher timestamp than expected, and extends the duration of the MediaStreamSource. Behavior seems fine from MediaPlayer, you see the progress bad change and playback continues without any noticeable gaps.

Current behavior is to first extend by 1 second, then by 2 (this time 0.5 seconds before reaching end), then, 3, 4, 5 and then always by 5. Not sure if this makes so much sense. Maybe we should just extend by 1 second all the time.

This is easy to test by reducing mediaDuration by factor 10 in InitFFmpegContext and then seek to near the end of the progress bar.

I have made this configurable, but enabed by default, because this is most probably what people expect. If the file is longer than expected, just continue playing.