### PR TITLE
Fix access violation when closing TexturePool

### DIFF
--- a/Source/TexturePool.h
+++ b/Source/TexturePool.h
@@ -23,10 +23,6 @@ public:
 
     void Clear()
     {
-        for (auto& texture : pool)
-        {
-            texture->Release();
-        }
         pool.clear();
         ZeroMemory(&desc_shared, sizeof(desc_shared));
     }


### PR DESCRIPTION
I am 100% sure that I have already seen that, and we talked about this somewhere. So I was really surprised to see that this is still in the codebase. Found this again when working on the auto ref PR.

The TexturePool has a list of com_refs. They will call Release() automatically when they are cleaned up. So we must not call AddRef() or Release() when using com_refs, as this dangerously gets into the way of automatic house keeping. Somehow, we still had Release() calls here, which could result in access violations if timing is bad.