### PR TITLE
Use interrupt callback for fast dispose

### DIFF
--- a/Samples/MediaPlayerCS/MainPage.xaml.cs
+++ b/Samples/MediaPlayerCS/MainPage.xaml.cs
@@ -280,12 +280,12 @@ namespace MediaPlayerCS
                 // If format cannot be detected, try to increase probesize, max_probe_packets and analyzeduration!
 
                 // Below are some sample options that you can set to configure RTSP streaming
-                // Config.FFmpegOptions.Add("rtsp_flags", "prefer_tcp");
-                Config.FFmpegOptions.Add("stimeout", 1000000);
-                Config.FFmpegOptions.Add("timeout", 1000000);
-                Config.FFmpegOptions.Add("reconnect", 1);
-                Config.FFmpegOptions.Add("reconnect_streamed", 1);
-                Config.FFmpegOptions.Add("reconnect_on_network_error", 1);
+                // Config.FFmpegOptions["rtsp_flags"] = "prefer_tcp";
+                Config.FFmpegOptions["stimeout"] = 1000000;
+                Config.FFmpegOptions["timeout"] = 1000000;
+                Config.FFmpegOptions["reconnect"] = 1;
+                Config.FFmpegOptions["reconnect_streamed"] = 1;
+                Config.FFmpegOptions["reconnect_on_network_error"] = 1;
 
                 // Instantiate FFmpegMediaSource using the URI
                 mediaPlayer.Source = null;

--- a/Samples/MediaPlayerWinUI/MainPage.xaml.cs
+++ b/Samples/MediaPlayerWinUI/MainPage.xaml.cs
@@ -250,12 +250,12 @@ namespace MediaPlayerWinUI
                     // If format cannot be detected, try to increase probesize, max_probe_packets and analyzeduration!
 
                     // Below are some sample options that you can set to configure RTSP streaming
-                    // Config.FFmpegOptions.Add("rtsp_flags", "prefer_tcp");
-                    Config.FFmpegOptions.Add("stimeout", 1000000);
-                    Config.FFmpegOptions.Add("timeout", 1000000);
-                    Config.FFmpegOptions.Add("reconnect", 1);
-                    Config.FFmpegOptions.Add("reconnect_streamed", 1);
-                    Config.FFmpegOptions.Add("reconnect_on_network_error", 1);
+                    // Config.FFmpegOptions["rtsp_flags"] = "prefer_tcp";
+                    Config.FFmpegOptions["stimeout"] = 1000000;
+                    Config.FFmpegOptions["timeout"] = 1000000;
+                    Config.FFmpegOptions["reconnect"] = 1;
+                    Config.FFmpegOptions["reconnect_streamed"] = 1;
+                    Config.FFmpegOptions["reconnect_on_network_error"] = 1;
 
                     // Instantiate FFmpegMediaSource using the URI
                     mediaPlayer.Source = null;

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -191,6 +191,7 @@ namespace winrt::FFmpegInteropX::implementation
         winrt::com_ptr<IStream> fileStreamData = { nullptr };
         ByteOrderMark streamByteOrderMark;
         winrt::com_ptr<MediaSourceConfig> config = { nullptr };
+        bool isShuttingDown = false;
 
 
     private:


### PR DESCRIPTION
This solves #323 and fixes a bug in the samples.