### PR TITLE
Align samples ffmpeg logging

### DIFF
--- a/Samples/MediaPlayerCPP/App.xaml.cpp
+++ b/Samples/MediaPlayerCPP/App.xaml.cpp
@@ -55,7 +55,7 @@ App::App()
 
 void App::Log(FFmpegInteropX::LogLevel level, String^ message)
 {
-    OutputDebugString(message->Data());
+    OutputDebugString((L"FFmpeg (" + level.ToString() + "): " + message)->Data());
 }
 
 /// <summary>

--- a/Samples/MediaPlayerCPP/MainPage.xaml.cpp
+++ b/Samples/MediaPlayerCPP/MainPage.xaml.cpp
@@ -541,13 +541,13 @@ void MediaPlayerCPP::MainPage::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, 
         return;
     }
 
-    if (args->VirtualKey == Windows::System::VirtualKey::V)
+    if (args->VirtualKey == Windows::System::VirtualKey::V && (Window::Current->CoreWindow->GetKeyState(Windows::System::VirtualKey::Control) == Windows::UI::Core::CoreVirtualKeyStates:: None))
     {
         if (playbackItem && playbackItem->VideoTracks->Size > 1)
         {
             bool reverse = (Window::Current->CoreWindow->GetKeyState(Windows::System::VirtualKey::Shift) & Windows::UI::Core::CoreVirtualKeyStates::Down) == Windows::UI::Core::CoreVirtualKeyStates::Down;
             int index = reverse ?
-                (playbackItem->VideoTracks->SelectedIndex - 1) % playbackItem->VideoTracks->Size :
+                (playbackItem->VideoTracks->SelectedIndex - 1 + playbackItem->VideoTracks->Size) % playbackItem->VideoTracks->Size : // % is not true modulo!
                 (playbackItem->VideoTracks->SelectedIndex + 1) % playbackItem->VideoTracks->Size;
             playbackItem->VideoTracks->SelectedIndex = index;
         }

--- a/Samples/MediaPlayerCS/App.xaml.cs
+++ b/Samples/MediaPlayerCS/App.xaml.cs
@@ -55,7 +55,7 @@ namespace MediaPlayerCS
 
         public void Log(LogLevel level, string message)
         {
-            System.Diagnostics.Debug.WriteLine("FFmpeg ({0}): {1}", level, message);
+            System.Diagnostics.Debug.Write($"FFmpeg ({level}): {message}");
         }
 
         /// <summary>

--- a/Samples/MediaPlayerCS/MainPage.xaml.cs
+++ b/Samples/MediaPlayerCS/MainPage.xaml.cs
@@ -104,13 +104,13 @@ namespace MediaPlayerCS
                 return;
             }
 
-            if (args.VirtualKey == VirtualKey.V)
+            if (args.VirtualKey == VirtualKey.V && Window.Current.CoreWindow.GetKeyState(VirtualKey.Control) == CoreVirtualKeyStates.None)
             {
                 if (playbackItem != null && playbackItem.VideoTracks.Count > 1)
                 {
-                    bool reverse = (Window.Current.CoreWindow.GetKeyState(VirtualKey.Control) & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
+                    bool reverse = (Window.Current.CoreWindow.GetKeyState(VirtualKey.Shift) & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
                     int index = reverse ?
-                        (playbackItem.VideoTracks.SelectedIndex - 1) % playbackItem.VideoTracks.Count :
+                        (playbackItem.VideoTracks.SelectedIndex - 1 + playbackItem.VideoTracks.Count) % playbackItem.VideoTracks.Count : // % is not true modulo!
                         (playbackItem.VideoTracks.SelectedIndex + 1) % playbackItem.VideoTracks.Count;
                     playbackItem.VideoTracks.SelectedIndex = index;
                 }

--- a/Samples/MediaPlayerWinUI/App.xaml.cs
+++ b/Samples/MediaPlayerWinUI/App.xaml.cs
@@ -1,3 +1,4 @@
+using FFmpegInteropX;
 using Microsoft.UI.Xaml;
 
 // To learn more about WinUI, the WinUI project structure,
@@ -8,7 +9,7 @@ namespace MediaPlayerWinUI
     /// <summary>
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
-    public partial class App : Application
+    public partial class App : Application, ILogProvider
     {
         /// <summary>
         /// Initializes the singleton application object.  This is the first line of authored code
@@ -17,6 +18,13 @@ namespace MediaPlayerWinUI
         public App()
         {
             this.InitializeComponent();
+            FFmpegInteropLogging.SetLogLevel(LogLevel.Info);
+            FFmpegInteropLogging.SetLogProvider(this);
+        }
+
+        public void Log(LogLevel level, string message)
+        {
+            System.Diagnostics.Debug.Write($"FFmpeg ({level}): {message}");
         }
 
         /// <summary>

--- a/Samples/MediaPlayerWinUI/MainPage.xaml.cs
+++ b/Samples/MediaPlayerWinUI/MainPage.xaml.cs
@@ -97,13 +97,13 @@ namespace MediaPlayerWinUI
                 return;
             }
 
-            if (args.Key == VirtualKey.V && !args.Handled)
+            if (args.Key == VirtualKey.V && Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control) == CoreVirtualKeyStates.None)
             {
                 if (playbackItem != null && playbackItem.VideoTracks.Count > 1)
                 {
-                    bool reverse = (Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control) & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
+                    bool reverse = (Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift) & CoreVirtualKeyStates.Down) == CoreVirtualKeyStates.Down;
                     int index = reverse ?
-                        (playbackItem.VideoTracks.SelectedIndex - 1) % playbackItem.VideoTracks.Count :
+                        (playbackItem.VideoTracks.SelectedIndex - 1 + playbackItem.VideoTracks.Count) % playbackItem.VideoTracks.Count : // % is not true modulo!
                         (playbackItem.VideoTracks.SelectedIndex + 1) % playbackItem.VideoTracks.Count;
                     playbackItem.VideoTracks.SelectedIndex = index;
                 }

--- a/Source/FFmpegInteropLogging.cpp
+++ b/Source/FFmpegInteropLogging.cpp
@@ -23,7 +23,7 @@ namespace winrt::FFmpegInteropX::implementation
             {
                 if (level <= av_log_get_level())
                 {
-                    if (s_pLogProvider != nullptr)
+                    if (auto provider = s_pLogProvider)
                     {
                         char pLine[1000];
                         int printPrefix = 1;
@@ -32,7 +32,7 @@ namespace winrt::FFmpegInteropX::implementation
                         wchar_t wLine[sizeof(pLine)];
                         if (MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, pLine, -1, wLine, sizeof(pLine)) != 0)
                         {
-                            s_pLogProvider.Log((LogLevel)level, hstring(wLine));
+                            provider.Log((LogLevel)level, hstring(wLine));
                         }
                     }
                 }
@@ -42,5 +42,6 @@ namespace winrt::FFmpegInteropX::implementation
     void FFmpegInteropLogging::SetDefaultLogProvider()
     {
         av_log_set_callback(av_log_default_callback);
+        s_pLogProvider = nullptr;
     }
 }


### PR DESCRIPTION
- Align ffmpeg logging in all samples, so we have same output for all of them
- Also fixes a bug when switching video streams in the samples