### PR TITLE
Lock all access to TexturePool

### DIFF
--- a/Source/D3D11VideoSampleProvider.h
+++ b/Source/D3D11VideoSampleProvider.h
@@ -65,6 +65,7 @@ public:
             if (!texturePool)
             {
                 // init texture pool, fail if we did not get a device ptr
+                std::lock_guard lock(samplesMutex);
                 if (device && deviceContext)
                 {
                     texturePool = std::unique_ptr<TexturePool>(new TexturePool(device, 5));
@@ -81,7 +82,10 @@ public:
                 auto decodedTexture = reinterpret_cast<ID3D11Texture2D*>(avFrame->data[0]);
                 winrt::com_ptr<ID3D11Texture2D> renderTexture;
                 //happy path:decoding and rendering on same GPU
-                hr = texturePool->GetCopyTexture(decodedTexture, renderTexture);
+                {
+                    std::lock_guard lock(samplesMutex);
+                    hr = texturePool->GetCopyTexture(decodedTexture, renderTexture);
+                }
                 deviceContext->CopySubresourceRegion(renderTexture.get(), 0, 0, 0, 0, decodedTexture, (UINT)(unsigned long long)avFrame->data[1], NULL);
                 deviceContext->Flush();
 
@@ -252,8 +256,11 @@ public:
             }
         }
 
-        texturePool.reset();
-        texturePool = nullptr;
+        {
+            std::lock_guard lock(samplesMutex);
+            texturePool.reset();
+            texturePool = nullptr;
+        }
 
         ReleaseTrackedSamples();
 


### PR DESCRIPTION
We only used the samplesMutex lock in places where trackedSamples list was accessed. But in Sample::OnProcessed, we also access the TexturePool from a different thread. This lead to occasional crashes, because the TexturePool is not inherently threadsafe. So I extended the locks to also cover all TexturePool access.

This should fix the crash seen in #320.