### PR TITLE
Auto select HDR mode

### DIFF
--- a/Source/D3D11VideoSampleProvider.h
+++ b/Source/D3D11VideoSampleProvider.h
@@ -26,8 +26,9 @@ public:
         AVCodecContext* avCodecCtx,
         winrt::FFmpegInteropX::MediaSourceConfig const& config,
         int streamIndex,
-        HardwareDecoderStatus hardwareDecoderStatus)
-        : UncompressedVideoSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex, hardwareDecoderStatus)
+        HardwareDecoderStatus hardwareDecoderStatus,
+        bool applyHdrColorInfo)
+        : UncompressedVideoSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex, hardwareDecoderStatus, applyHdrColorInfo)
     {
         decoder = DecoderEngine::FFmpegD3D11HardwareDecoder;
         hwCodec = avCodecCtx->codec;

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -49,6 +49,13 @@ namespace FFmpegInteropX
         ForceFFmpegSoftwareDecoder
     };
 
+    enum HdrSupport
+    {
+        Automatic,
+        Enabled,
+        Disabled
+    };
+
     [flags]
     ///<summary>This flags enumeration describes the content or intention of a stream.</summary>
     enum StreamDisposition
@@ -523,8 +530,11 @@ namespace FFmpegInteropX
         ///<remarks>This could allow hardware decoding on some platforms (e.g. Windows Phone).</remarks>
         Boolean PassthroughAudioAAC{ get; set; };
 
-        ///<summary>Sets the video decoder mode. Default is AutoDetection.</summary>
+        ///<summary>The video decoder mode. Default is Automatic.</summary>
         VideoDecoderMode VideoDecoderMode{ get; set; };
+
+        ///<summary>The HDR color support mode. Default is Automatic.</summary>
+        HdrSupport HdrSupport{ get; set; };
 
         ///<summary>Max profile allowed for H264 system decoder. Default: High Profile (100). See FF_PROFILE_H264_* values.</summary>
         Int32 SystemDecoderH264MaxProfile{ get; set; };

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -171,12 +171,12 @@ namespace winrt::FFmpegInteropX::implementation
         void OnPresentationModeChanged(MediaPlaybackTimedMetadataTrackList  const& sender, TimedMetadataPresentationModeChangedEventArgs  const& args);
         void InitializePlaybackItem(MediaPlaybackItem  const& playbackitem);
         bool CheckUseHardwareAcceleration(AVCodecContext* avCodecCtx, HardwareAccelerationStatus const& status, HardwareDecoderStatus& hardwareDecoderStatus, int maxProfile, int maxLevel);
+        static void CheckUseHdr(winrt::com_ptr<MediaSourceConfig> const& config);
         void CheckExtendDuration(MediaStreamSample sample);
 
     public://internal:
         static winrt::com_ptr<FFmpegMediaSource> CreateFromStream(IRandomAccessStream const& stream, winrt::com_ptr<MediaSourceConfig> const& config, DispatcherQueue  const& dispatcher);
         static winrt::com_ptr<FFmpegMediaSource> CreateFromUri(hstring  const& uri, winrt::com_ptr<MediaSourceConfig>  const& config, DispatcherQueue  const& dispatcher);
-        static winrt::com_ptr<FFmpegMediaSource> CreateFromUri(hstring  const& uri, winrt::com_ptr<MediaSourceConfig>  const& config);
         HRESULT Seek(TimeSpan const& position, TimeSpan& actualPosition, bool allowFastSeek);
 
         std::shared_ptr<MediaSampleProvider> VideoSampleProvider()

--- a/Source/FrameGrabber.cpp
+++ b/Source/FrameGrabber.cpp
@@ -40,7 +40,7 @@ namespace winrt::FFmpegInteropX::implementation
         config->IsFrameGrabber = true;
         config->VideoDecoderMode(VideoDecoderMode::ForceFFmpegSoftwareDecoder);
 
-        auto result = FFmpegMediaSource::CreateFromUri(uri, config);
+        auto result = FFmpegMediaSource::CreateFromUri(uri, config, nullptr);
         if (result == nullptr)
         {
             throw_hresult(E_FAIL);

--- a/Source/MediaSourceConfig.h
+++ b/Source/MediaSourceConfig.h
@@ -36,8 +36,11 @@ namespace winrt::FFmpegInteropX::implementation
         ///<remarks>This could allow hardware decoding on some platforms (e.g. Windows Phone).</remarks>
         PROPERTY(PassthroughAudioAAC, bool, false);
 
-        ///<summary>Sets the video decoder mode. Default is AutoDetection.</summary>
+        ///<summary>Sets the video decoder mode. Default is Automatic.</summary>
         PROPERTY(VideoDecoderMode, FFmpegInteropX::VideoDecoderMode, VideoDecoderMode::Automatic);
+
+        ///<summary>Sets the HDR color support mode. Default is Automatic.</summary>
+        PROPERTY(HdrSupport, FFmpegInteropX::HdrSupport, HdrSupport::Automatic);
 
         ///<summary>Max profile allowed for H264 system decoder. Default: High Profile (100). See FF_PROFILE_H264_* values.</summary>
         PROPERTY(SystemDecoderH264MaxProfile, int32_t, FF_PROFILE_H264_HIGH);
@@ -191,6 +194,8 @@ namespace winrt::FFmpegInteropX::implementation
         bool IsFrameGrabber;
         /*Internal use:determines if a FFmpegInteropInstance is in external subtitle parser mode. This mode is used to parse files which contain only subtitle streams*/
         bool IsExternalSubtitleParser;
+        //Apply hdr color info, if available in the file
+        bool ApplyHdrColorInfo;
 
         /*Used to pass additional, specific options to external sub parsers*/
         PropertySet AdditionalFFmpegSubtitleOptions = {nullptr};

--- a/Source/UncompressedVideoSampleProvider.h
+++ b/Source/UncompressedVideoSampleProvider.h
@@ -59,7 +59,8 @@ public:
         AVCodecContext* avCodecCtx,
         MediaSourceConfig const& config,
         int streamIndex,
-        HardwareDecoderStatus hardwareDecoderStatus);
+        HardwareDecoderStatus hardwareDecoderStatus,
+        bool applyHdrColorInfo);
     winrt::Windows::Media::Core::IMediaStreamDescriptor CreateStreamDescriptor() override;
     virtual HRESULT CreateBufferFromFrame(winrt::Windows::Storage::Streams::IBuffer* pBuffer, winrt::Windows::Graphics::DirectX::Direct3D11::IDirect3DSurface* surface, AVFrame* avFrame, int64_t& framePts, int64_t& frameDuration) override;
     virtual HRESULT SetSampleProperties(winrt::Windows::Media::Core::MediaStreamSample  const& sample) override;
@@ -93,6 +94,7 @@ private:
     int outputFrameHeight = 0;
     int outputFrameWidth = 0;
     bool outputDirectBuffer = 0;
+    bool applyHdrColorInfo = false;
 
     AVBufferPool* sourceBufferPool = NULL;
     int sourceBufferPoolSize = 0;

--- a/Source/pch.h
+++ b/Source/pch.h
@@ -10,6 +10,8 @@
 #undef TRY
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Graphics.Display.h>
+#include <winrt/Windows.Graphics.Display.Core.h>
 #include <winrt/Windows.Graphics.DirectX.Direct3D11.h>
 #include <winrt/Windows.Graphics.DirectX.h>
 #include <winrt/Windows.Graphics.Imaging.h>


### PR DESCRIPTION
A new setting was added to allow selection of HDR mode. Default is "Automatic", which will check the display properties to see if HDR is enabled. Only then, HDR metadata will be forwarded.

Note: This currently does not work on WinUI, because it has its own DisplayInformation implementation. We need a separate WinUI build to support this.