### PR TITLE
Disable Terminal Escape Codes

### DIFF
--- a/Build/FFmpegConfig.sh
+++ b/Build/FFmpegConfig.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )
 
+export TERM=dumb
+
 declare -A arch
 arch['x86']='x86'
 arch['x64']='x86_64'


### PR DESCRIPTION
In case of build errors I had seen ANSI escape sequences in the output right before the transcript stopped:

```
INSTALL	libavutil/avconfig.h
INSTALL	libavutil/ffversion.h
INSTALL	libavutil/libavutil.pc
[H[2J[3J
**********************
Windows PowerShell transcript end
End time: 20230924082823
**********************
```

From this I got unsure whether there might be an issue with character encoding and whether the transcript might have been truncated.

This PR avoids those escape sequences.