### PR TITLE
Improve subtitle character encoding detection

### DIFF
--- a/Samples/MediaPlayerCPP/MainPage.xaml.cpp
+++ b/Samples/MediaPlayerCPP/MainPage.xaml.cpp
@@ -67,7 +67,7 @@ MainPage::MainPage()
     mediaPlayerElement->SetMediaPlayer(mediaPlayer);
 
     // populate character encodings
-    cbEncodings->ItemsSource = CharacterEncoding::GetCharacterEncodings();
+    cbEncodings->ItemsSource = CharacterEncoding::AllEncodings;
 
     Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyDown += ref new Windows::Foundation::TypedEventHandler<Windows::UI::Core::CoreWindow^, Windows::UI::Core::KeyEventArgs^>(this, &MediaPlayerCPP::MainPage::OnKeyDown);
     
@@ -445,7 +445,7 @@ void MediaPlayerCPP::MainPage::CbEncodings_SelectionChanged(Platform::Object^ se
 {
     if (cbEncodings->SelectedItem)
     {
-        Config->AnsiSubtitleEncoding = static_cast<CharacterEncoding^>(cbEncodings->SelectedItem);
+        Config->ExternalSubtitleAnsiEncoding = static_cast<CharacterEncoding^>(cbEncodings->SelectedItem);
     }
 }
 

--- a/Samples/MediaPlayerCS/MainPage.xaml.cs
+++ b/Samples/MediaPlayerCS/MainPage.xaml.cs
@@ -78,7 +78,7 @@ namespace MediaPlayerCS
             CodecChecker.CodecRequired += CodecChecker_CodecRequired;
 
             // populate character encodings
-            cbEncodings.ItemsSource = CharacterEncoding.GetCharacterEncodings();
+            cbEncodings.ItemsSource = CharacterEncoding.AllEncodings;
 
             CoreWindow.GetForCurrentThread().KeyDown += MainPage_KeyDown;
 
@@ -459,7 +459,7 @@ namespace MediaPlayerCS
         {
             if (cbEncodings.SelectedItem != null)
             {
-                Config.AnsiSubtitleEncoding = (CharacterEncoding)cbEncodings.SelectedItem;
+                Config.ExternalSubtitleAnsiEncoding = (CharacterEncoding)cbEncodings.SelectedItem;
             }
         }
 

--- a/Samples/MediaPlayerWinUI/MainPage.xaml.cs
+++ b/Samples/MediaPlayerWinUI/MainPage.xaml.cs
@@ -71,7 +71,7 @@ namespace MediaPlayerWinUI
             CodecChecker.CodecRequired += CodecChecker_CodecRequired;
 
             // populate character encodings
-            cbEncodings.ItemsSource = CharacterEncoding.GetCharacterEncodings();
+            cbEncodings.ItemsSource = CharacterEncoding.AllEncodings;
 
             AddHandler(KeyDownEvent, new KeyEventHandler(MainPage_KeyDown), true);
 
@@ -432,7 +432,7 @@ namespace MediaPlayerWinUI
         {
             if (cbEncodings.SelectedItem != null)
             {
-                Config.AnsiSubtitleEncoding = (CharacterEncoding)cbEncodings.SelectedItem;
+                Config.ExternalSubtitleAnsiEncoding = (CharacterEncoding)cbEncodings.SelectedItem;
             }
         }
 

--- a/Source/CharacterEncoding.cpp
+++ b/Source/CharacterEncoding.cpp
@@ -8,7 +8,7 @@
 
 namespace winrt::FFmpegInteropX::implementation
 {
-    Windows::Foundation::Collections::IVectorView<FFmpegInteropX::CharacterEncoding> CharacterEncoding::GetCharacterEncodings()
+    Windows::Foundation::Collections::IVectorView<FFmpegInteropX::CharacterEncoding> CharacterEncoding::AllEncodings()
     {
         if (internalView == nullptr)
         {
@@ -203,9 +203,35 @@ namespace winrt::FFmpegInteropX::implementation
     {
     }
 
-    FFmpegInteropX::CharacterEncoding CharacterEncoding::GetSystemDefault()
+    FFmpegInteropX::CharacterEncoding CharacterEncoding::SystemLocale()
     {
-        return GetCharacterEncodings().GetAt(0);
+        return AllEncodings().GetAt(0);
+    }
+
+    FFmpegInteropX::CharacterEncoding CharacterEncoding::ASCII()
+    {
+        auto encodings = AllEncodings();
+        for (auto encoding : encodings)
+        {
+            if (encoding.WindowsCodePage() == 20127)
+            {
+                return encoding;
+            }
+        }
+        throw_hresult(E_FAIL);
+    }
+
+    FFmpegInteropX::CharacterEncoding CharacterEncoding::UTF8()
+    {
+        auto encodings = AllEncodings();
+        for (auto encoding : encodings)
+        {
+            if (encoding.WindowsCodePage() == 65001)
+            {
+                return encoding;
+            }
+        }
+        throw_hresult(E_FAIL);
     }
 
     hstring CharacterEncoding::Name()

--- a/Source/CharacterEncoding.h
+++ b/Source/CharacterEncoding.h
@@ -12,8 +12,10 @@ namespace winrt::FFmpegInteropX::implementation
     {
         CharacterEncoding(int p_codePage, hstring const& p_name, hstring const& p_description);
 
-        static Windows::Foundation::Collections::IVectorView<FFmpegInteropX::CharacterEncoding> GetCharacterEncodings();
-        static FFmpegInteropX::CharacterEncoding GetSystemDefault();
+        static Windows::Foundation::Collections::IVectorView<FFmpegInteropX::CharacterEncoding> AllEncodings();
+        static FFmpegInteropX::CharacterEncoding SystemLocale();
+        static FFmpegInteropX::CharacterEncoding ASCII();
+        static FFmpegInteropX::CharacterEncoding UTF8();
         hstring Name();
         hstring Description();
         int32_t WindowsCodePage();

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -253,8 +253,10 @@ namespace FFmpegInteropX
         String Name {get; };
         String Description{ get; };
         Int32 WindowsCodePage{ get; };
-        static Windows.Foundation.Collections.IVectorView<CharacterEncoding> GetCharacterEncodings();
-        static CharacterEncoding GetSystemDefault();
+        static Windows.Foundation.Collections.IVectorView<CharacterEncoding> AllEncodings{ get; };
+        static CharacterEncoding SystemLocale{ get; };
+        static CharacterEncoding ASCII{ get; };
+        static CharacterEncoding UTF8{ get; };
     };
 
     runtimeclass CodecRequiredEventArgs
@@ -677,7 +679,7 @@ namespace FFmpegInteropX
         /// <summary>
         /// The character encoding used for external subtitle files.
         ///
-        /// When null, auto detection is used.
+        /// When null, auto detection is used. This is the default and recommended.
         /// If ANSI encoding is auto detected, will use ExternalSubtitleAnsiEncoding.
         /// </summary>
         CharacterEncoding ExternalSubtitleEncoding{ get; set; };

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -674,11 +674,18 @@ namespace FFmpegInteropX
         ///<summary>Default style to use for subtitles.</summary>
         Windows.Media.Core.TimedTextStyle SubtitleStyle{ get; set; };
 
-        ///<summary>Enable conversion of ANSI encoded subtitles to UTF-8.</summary>
-        Boolean AutoCorrectAnsiSubtitles{ get; set; };
+        /// <summary>
+        /// The character encoding used for external subtitle files.
+        ///
+        /// When null, auto detection is used.
+        /// If ANSI encoding is auto detected, will use ExternalSubtitleAnsiEncoding.
+        /// </summary>
+        CharacterEncoding ExternalSubtitleEncoding{ get; set; };
 
-        ///<summary>The character encoding used to decode ANSI encoded subtitles. By default, the active windows codepage is used.</summary>
-        CharacterEncoding AnsiSubtitleEncoding{ get; set; };
+        /// <summary>
+        /// The character encoding to use if ANSI encoding is detected for external subtitle files.
+        /// </summary>
+        CharacterEncoding ExternalSubtitleAnsiEncoding{ get; set; };
 
         ///<summary>The subtitle delay will be initially applied to all subtitle tracks.
         ///Use SetSubtitleDelay() on the FFmpegMediaSource instance if you want to change the delay during playback.</summary>

--- a/Source/FFmpegInteropX.vcxproj
+++ b/Source/FFmpegInteropX.vcxproj
@@ -215,6 +215,7 @@
     <ClInclude Include="SubtitleProviderSsaAss.h" />
     <ClInclude Include="SubtitleStreamInfo.h" />
     <ClInclude Include="TexturePool.h" />
+    <ClInclude Include="text_encoding_detect.h" />
     <ClInclude Include="TimeSpanHelpers.h" />
     <ClInclude Include="UncompressedAudioSampleProvider.h" />
     <ClInclude Include="UncompressedFrameProvider.h" />
@@ -260,6 +261,7 @@
     <ClCompile Include="SubtitleProvider.cpp" />
     <ClCompile Include="SubtitleProviderSsaAss.cpp" />
     <ClCompile Include="SubtitleStreamInfo.cpp" />
+    <ClCompile Include="text_encoding_detect.cpp" />
     <ClCompile Include="UncompressedAudioSampleProvider.cpp" />
     <ClCompile Include="UncompressedSampleProvider.cpp" />
     <ClCompile Include="UncompressedVideoSampleProvider.cpp" />

--- a/Source/FFmpegInteropX.vcxproj.filters
+++ b/Source/FFmpegInteropX.vcxproj.filters
@@ -215,6 +215,9 @@
     <ClInclude Include="LanguageTagConverter.h">
       <Filter>Helpers</Filter>
     </ClInclude>
+    <ClInclude Include="text_encoding_detect.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CodecChecker.cpp" />
@@ -304,6 +307,9 @@
       <Filter>Metadata</Filter>
     </ClCompile>
     <ClCompile Include="LanguageTagConverter.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="text_encoding_detect.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -2409,7 +2409,7 @@ namespace winrt::FFmpegInteropX::implementation
         {
             // Make sure we have at least 4 bytes for BOM check
             bool isEof = false;
-            while (bytesRead < min(bufSize,4))
+            while (bytesRead < min(bufSize,4) && !isEof)
             {
                 ULONG read = 0;
                 hr = mss->fileStreamData->Read(buf + bytesRead, bufSize - bytesRead, &read);
@@ -2420,7 +2420,6 @@ namespace winrt::FFmpegInteropX::implementation
                 else if (read == 0)
                 {
                     isEof = true;
-                    break;
                 }
 
                 bytesRead += read;
@@ -2442,7 +2441,6 @@ namespace winrt::FFmpegInteropX::implementation
                     else if (read == 0)
                     {
                         isEof = true;
-                        break;
                     }
 
                     bytesRead += read;

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -742,26 +742,11 @@ namespace winrt::FFmpegInteropX::implementation
 
             //inject custom properties
             if (config->AutoCorrectAnsiSubtitles() && config->IsExternalSubtitleParser &&
-                (streamEncoding != TextEncodingDetect::UTF8_BOM && streamEncoding != TextEncodingDetect::UTF8_NOBOM && streamEncoding != TextEncodingDetect::None))
+                (streamEncoding == TextEncodingDetect::ANSI || streamEncoding == TextEncodingDetect::ASCII))
             {
                 hstring key = config->AnsiSubtitleEncoding().Name();
                 std::string keyA = StringUtils::PlatformStringToUtf8String(key);
-                const char* keyChar;
-
-                switch (streamEncoding)
-                {
-                case TextEncodingDetect::UTF16_LE_BOM:
-                case TextEncodingDetect::UTF16_LE_NOBOM:
-                    keyChar = "CP1200";
-                    break;
-                case TextEncodingDetect::UTF16_BE_BOM:
-                case TextEncodingDetect::UTF16_BE_NOBOM:
-                    keyChar = "CP1201";
-                    break;
-                default:
-                    keyChar = keyA.c_str(); // ANSI or ASCII detected. Use selected encoding from settings.
-                    break;
-                }
+                const char* keyChar = keyA.c_str();
 
                 if (av_opt_set(avSubsCodecCtx, "sub_charenc", keyChar, AV_OPT_SEARCH_CHILDREN) < 0)
                 {
@@ -2422,9 +2407,9 @@ namespace winrt::FFmpegInteropX::implementation
         // Check encoding in case of external subtitle parser
         if (!mss->streamEncodingChecked && mss->config->IsExternalSubtitleParser)
         {
-            // read at least 1kb for first probing
+            // Make sure we have at least 4 bytes for BOM check
             bool isEof = false;
-            while (bytesRead < min(bufSize,1024))
+            while (bytesRead < min(bufSize,4))
             {
                 ULONG read = 0;
                 hr = mss->fileStreamData->Read(buf + bytesRead, bufSize - bytesRead, &read);
@@ -2445,36 +2430,29 @@ namespace winrt::FFmpegInteropX::implementation
             auto encoding = TextEncodingDetect::CheckBOM(buf, bytesRead);
             if (encoding == TextEncodingDetect::None)
             {
-                // now do first probe
-                TextEncodingDetect detect;
-                encoding = detect.DetectEncoding(buf, bytesRead);
-
-                // if encoding seems to be some kind of UTF, be sure to read the full chunk, then probe again
-                if (encoding != TextEncodingDetect::None && encoding != TextEncodingDetect::ANSI && !isEof && bytesRead < bufSize)
+                // if no BOM is present, make sure we read the first chunk for full probing
+                while (bytesRead < bufSize && !isEof)
                 {
-                    while (bytesRead < bufSize)
+                    ULONG read = 0;
+                    hr = mss->fileStreamData->Read(buf + bytesRead, bufSize - bytesRead, &read);
+                    if (FAILED(hr))
                     {
-                        ULONG read = 0;
-                        hr = mss->fileStreamData->Read(buf + bytesRead, bufSize - bytesRead, &read);
-                        if (FAILED(hr))
-                        {
-                            return -1;
-                        }
-                        else if (read == 0)
-                        {
-                            isEof = true;
-                            break;
-                        }
-
-                        bytesRead += read;
+                        return -1;
+                    }
+                    else if (read == 0)
+                    {
+                        isEof = true;
+                        break;
                     }
 
-                    encoding = detect.DetectEncoding(buf, bytesRead);
+                    bytesRead += read;
                 }
 
-                mss->streamEncoding = encoding;
+                TextEncodingDetect detect;
+                encoding = detect.DetectEncoding(buf, bytesRead);
             }
 
+            mss->streamEncoding = encoding;
             mss->streamEncodingChecked = true;
         }
 

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -13,6 +13,7 @@
 #include "SubtitleStreamInfo.h"
 #include "ChapterInfo.h"
 #include "FormatInfo.h"
+#include "text_encoding_detect.h"
 
 // Note: Remove this static_assert after copying these generated source files to your project.
 // This assertion exists to avoid compiling these generated source files directly.
@@ -29,13 +30,7 @@ namespace winrt::FFmpegInteropX::implementation
     namespace WFM = winrt::Windows::Foundation::Metadata;
     using namespace winrt::Windows::Storage::Streams;
     using namespace winrt::Windows::System;
-
-    enum ByteOrderMark
-    {
-        Unchecked,
-        Unknown,
-        UTF8
-    };
+    using namespace TextEncoding;
 
     struct FFmpegMediaSource : FFmpegMediaSourceT<FFmpegMediaSource>
     {
@@ -237,7 +232,8 @@ namespace winrt::FFmpegInteropX::implementation
         AVIOContext* avIOCtx = nullptr;
         AVFormatContext* avFormatCtx = nullptr;
         winrt::com_ptr<IStream> fileStreamData = { nullptr };
-        ByteOrderMark streamByteOrderMark;
+        TextEncodingDetect::Encoding streamEncoding = TextEncodingDetect::None;
+        bool streamEncodingChecked = false;
         winrt::com_ptr<MediaSourceConfig> config = { nullptr };
         bool isShuttingDown = false;
 

--- a/Source/MediaSourceConfig.h
+++ b/Source/MediaSourceConfig.h
@@ -128,11 +128,18 @@ namespace winrt::FFmpegInteropX::implementation
         ///<summary>Default style to use for subtitles.</summary>
         PROPERTY_CONST(SubtitleStyle, TimedTextStyle, CreateDefaultSubtitleStyle());
 
-        ///<summary>Enable conversion of ANSI encoded subtitles to UTF-8.</summary>
-        PROPERTY(AutoCorrectAnsiSubtitles, bool, true);
+        /// <summary>
+        /// The character encoding used for external subtitle files.
+        ///
+        /// When null, auto detection is used.
+        /// If ANSI encoding is auto detected, will use ExternalSubtitleAnsiEncoding.
+        /// </summary>
+        PROPERTY_CONST(ExternalSubtitleEncoding, FFmpegInteropX::CharacterEncoding, nullptr);
 
-        ///<summary>The character encoding used to decode ANSI encoded subtitles. By default, the active windows codepage is used.</summary>
-        PROPERTY_CONST(AnsiSubtitleEncoding, FFmpegInteropX::CharacterEncoding, CharacterEncoding::GetSystemDefault());
+        /// <summary>
+        /// The character encoding to use if ANSI encoding is detected for external subtitle files.
+        /// </summary>
+        PROPERTY_CONST(ExternalSubtitleAnsiEncoding, FFmpegInteropX::CharacterEncoding, CharacterEncoding::GetSystemDefault());
 
         ///<summary>The subtitle delay will be initially applied to all subtitle tracks.
         ///Use SetSubtitleDelay() on the FFmpegMediaSource instance if you want to change the delay during playback.</summary>

--- a/Source/MediaSourceConfig.h
+++ b/Source/MediaSourceConfig.h
@@ -131,7 +131,7 @@ namespace winrt::FFmpegInteropX::implementation
         /// <summary>
         /// The character encoding used for external subtitle files.
         ///
-        /// When null, auto detection is used.
+        /// When null, auto detection is used. This is the default and recommended.
         /// If ANSI encoding is auto detected, will use ExternalSubtitleAnsiEncoding.
         /// </summary>
         PROPERTY_CONST(ExternalSubtitleEncoding, FFmpegInteropX::CharacterEncoding, nullptr);
@@ -139,7 +139,7 @@ namespace winrt::FFmpegInteropX::implementation
         /// <summary>
         /// The character encoding to use if ANSI encoding is detected for external subtitle files.
         /// </summary>
-        PROPERTY_CONST(ExternalSubtitleAnsiEncoding, FFmpegInteropX::CharacterEncoding, CharacterEncoding::GetSystemDefault());
+        PROPERTY_CONST(ExternalSubtitleAnsiEncoding, FFmpegInteropX::CharacterEncoding, CharacterEncoding::SystemLocale());
 
         ///<summary>The subtitle delay will be initially applied to all subtitle tracks.
         ///Use SetSubtitleDelay() on the FFmpegMediaSource instance if you want to change the delay during playback.</summary>

--- a/Source/text_encoding_detect.cpp
+++ b/Source/text_encoding_detect.cpp
@@ -1,0 +1,364 @@
+//
+// Copyright 2015-2016 Jonathan Bennett <jon@autoitscript.com>
+// 
+// https://www.autoitscript.com 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+// Includes
+#include "pch.h"
+#include "text_encoding_detect.h"
+
+using namespace TextEncoding;
+
+static const unsigned char TextEncodingDetect_UTF16_BOM_LE[] = { unsigned char(0xFF), unsigned char(0xFE) };
+static const unsigned char TextEncodingDetect_UTF16_BOM_BE[] = { unsigned char(0xFE), unsigned char(0xFF) };
+static const unsigned char TextEncodingDetect_UTF8_BOM[] = { unsigned char(0xEF), unsigned char(0xBB), unsigned char(0xBF) };
+
+const unsigned char* TextEncodingDetect::utf16_bom_le_ = TextEncodingDetect_UTF16_BOM_LE;
+const unsigned char* TextEncodingDetect::utf16_bom_be_ = TextEncodingDetect_UTF16_BOM_BE;
+const unsigned char* TextEncodingDetect::utf8_bom_ = TextEncodingDetect_UTF8_BOM;
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Constructor()
+// Default constructor
+///////////////////////////////////////////////////////////////////////////////
+
+TextEncodingDetect::TextEncodingDetect()
+{
+	// By default, assume nulls can't appear in ANSI/ASCII/UTF8 text files
+	null_suggests_binary_ = true;	
+
+	// Set defaults for utf16 detection based the use of odd/even nulls
+	utf16_expected_null_percent_ = 70;
+	utf16_unexpected_null_percent_ = 10;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Destructor()
+///////////////////////////////////////////////////////////////////////////////
+
+TextEncodingDetect::~TextEncodingDetect()
+{
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Set the percentages used in utf16 detection using nulls.
+///////////////////////////////////////////////////////////////////////////////
+
+void TextEncodingDetect::SetUtf16UnexpectedNullPercent(int percent) 
+{
+	if (percent > 0 && percent < 100)
+		utf16_unexpected_null_percent_ = percent; 
+}
+
+void TextEncodingDetect::SetUtf16ExpectedNullPercent(int percent) 
+{
+	if (percent > 0 && percent < 100)
+		utf16_expected_null_percent_ = percent;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Simple function to return the length of the BOM for a particular encoding
+// mode.
+///////////////////////////////////////////////////////////////////////////////
+
+int TextEncodingDetect::GetBOMLengthFromEncodingMode(Encoding encoding)
+{
+	int length = 0;
+
+	if (encoding == UTF16_BE_BOM || encoding == UTF16_LE_BOM)
+		length = 2;
+	else if (encoding == UTF8_BOM)
+		length = 3;
+
+	return length;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Checks if a buffer contains a valid BOM and returns the encoding based on it.
+// Returns encoding "None" if there is no BOM.
+///////////////////////////////////////////////////////////////////////////////
+
+TextEncodingDetect::Encoding TextEncodingDetect::CheckBOM(const unsigned char *pBuffer, size_t size)
+{
+	// Check for BOM
+	if (size >= 2 && pBuffer[0] == utf16_bom_le_[0] && pBuffer[1] == utf16_bom_le_[1])
+	{
+		return UTF16_LE_BOM;
+	}
+	else if (size >= 2 && pBuffer[0] == utf16_bom_be_[0] && pBuffer[1] == utf16_bom_be_[1])
+	{
+		return UTF16_BE_BOM;
+	}
+	else if (size >= 3 && pBuffer[0] == utf8_bom_[0] && pBuffer[1] == utf8_bom_[1] && pBuffer[2] == utf8_bom_[2])
+	{
+		return UTF8_BOM;
+	}
+	else
+	{
+		return None;
+	}
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Checks if a buffer contains a valid BOM and returns the encoding based on it.
+// If it doesn't contain a BOM it tries to guess what the encoding is or
+// "None" if it just looks like binary data.
+///////////////////////////////////////////////////////////////////////////////
+
+TextEncodingDetect::Encoding TextEncodingDetect::DetectEncoding(const unsigned char *pBuffer, size_t size) const
+{
+	// First check if we have a BOM and return that if so
+	Encoding encoding = CheckBOM(pBuffer, size);
+	if (encoding != None)
+		return encoding;
+
+	// Now check for valid UTF8
+	encoding = CheckUTF8(pBuffer, size);
+	if (encoding != None)
+		return encoding;
+
+	// Now try UTF16 
+	encoding = CheckUTF16NewlineChars(pBuffer, size);
+	if (encoding != None)
+		return encoding;
+
+	encoding = CheckUTF16ASCII(pBuffer, size);
+	if (encoding != None)
+		return encoding;
+
+	// ANSI or None (binary) then
+	if (!DoesContainNulls(pBuffer, size))
+		return ANSI;
+	else
+	{
+		// Found a null, return based on the preference in null_suggests_binary_
+		if (null_suggests_binary_)
+			return None;
+		else
+			return ANSI;
+	}
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Checks if a buffer contains valid utf8. Returns:
+// None - not valid utf8
+// UTF8_NOBOM - valid utf8 encodings and multibyte sequences
+// ASCII - Only data in the 0-127 range. 
+///////////////////////////////////////////////////////////////////////////////
+
+TextEncodingDetect::Encoding TextEncodingDetect::CheckUTF8(const unsigned char *pBuffer, size_t size) const
+{
+	// UTF8 Valid sequences
+	// 0xxxxxxx  ASCII
+	// 110xxxxx 10xxxxxx  2-byte
+	// 1110xxxx 10xxxxxx 10xxxxxx  3-byte
+	// 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx  4-byte
+	//
+	// Width in UTF8
+	// Decimal		Width
+	// 0-127		1 byte
+	// 194-223		2 bytes
+	// 224-239		3 bytes
+	// 240-244		4 bytes
+	//
+	// Subsequent chars are in the range 128-191
+
+	bool	only_saw_ascii_range = true;
+	size_t	pos = 0;
+	int		more_chars;
+
+	while (pos < size)
+	{
+		unsigned char ch = pBuffer[pos++];
+
+		if (ch == 0 && null_suggests_binary_)
+		{
+			return None;
+		}
+		else if (ch <= 127)
+		{
+			// 1 byte
+			more_chars = 0;
+		}
+		else if (ch >= 194 && ch <= 223)
+		{
+			// 2 Byte
+			more_chars = 1;
+		}
+		else if (ch >= 224 && ch <= 239)
+		{
+			// 3 Byte
+			more_chars = 2;
+		}
+		else if (ch >= 240 && ch <= 244)
+		{
+			// 4 Byte
+			more_chars = 3;
+		}
+		else
+		{
+			return None;						// Not utf8
+		}
+
+		// Check secondary chars are in range if we are expecting any
+		while (more_chars && pos < size)
+		{
+			only_saw_ascii_range = false;		// Seen non-ascii chars now
+
+			ch = pBuffer[pos++];
+			if (ch < 128 || ch > 191)
+				return None;					// Not utf8
+
+			--more_chars;
+		}
+	}
+
+	// If we get to here then only valid UTF-8 sequences have been processed
+
+	// If we only saw chars in the range 0-127 then we can't assume UTF8 (the caller will need to decide)
+	if (only_saw_ascii_range)
+		return ASCII;
+	else
+		return UTF8_NOBOM;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Checks if a buffer contains text that looks like utf16 by scanning for 
+// newline chars that would be present even in non-english text.
+// Returns:
+// None - not valid utf16
+// UTF16_LE_NOBOM - looks like utf16 le
+// UTF16_BE_NOBOM - looks like utf16 be
+///////////////////////////////////////////////////////////////////////////////
+
+TextEncodingDetect::Encoding TextEncodingDetect::CheckUTF16NewlineChars(const unsigned char *pBuffer, size_t size)
+{
+	if (size < 2)
+		return None;
+
+	// Reduce size by 1 so we don't need to worry about bounds checking for pairs of bytes
+	size--;
+
+	int le_control_chars = 0;
+	int be_control_chars = 0;
+	unsigned char ch1, ch2;
+
+	size_t pos = 0;
+	while (pos < size)
+	{
+		ch1 = pBuffer[pos++];
+		ch2 = pBuffer[pos++];
+
+		if (ch1 == 0)
+		{
+			if (ch2 == 0x0a || ch2 == 0x0d)
+				++be_control_chars;
+		}
+		else if (ch2 == 0)
+		{
+			if (ch1 == 0x0a || ch1 == 0x0d)
+				++le_control_chars;
+		}
+
+		// If we are getting both LE and BE control chars then this file is not utf16
+		if (le_control_chars && be_control_chars)
+			return None;
+	}
+
+	if (le_control_chars)
+		return UTF16_LE_NOBOM;
+	else if (be_control_chars)
+		return UTF16_BE_NOBOM;
+	else
+		return None;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Checks if a buffer contains text that looks like utf16. This is done based
+// the use of nulls which in ASCII/script like text can be useful to identify.
+// Returns:
+// None - not valid utf16
+// UTF16_LE_NOBOM - looks like utf16 le
+// UTF16_BE_NOBOM - looks like utf16 be
+///////////////////////////////////////////////////////////////////////////////
+
+TextEncodingDetect::Encoding TextEncodingDetect::CheckUTF16ASCII(const unsigned char *pBuffer, size_t size) const
+{
+	int num_odd_nulls = 0;
+	int num_even_nulls = 0;
+
+	// Get even nulls
+	size_t pos = 0;
+	while (pos < size)
+	{
+		if (pBuffer[pos] == 0)
+			num_even_nulls++;
+
+		pos += 2;
+	}
+
+	// Get odd nulls
+	pos = 1;
+	while (pos < size)
+	{
+		if (pBuffer[pos] == 0)
+			num_odd_nulls++;
+
+		pos += 2;
+	}
+
+	double even_null_threshold = (num_even_nulls * 2.0) / size;
+	double odd_null_threshold = (num_odd_nulls * 2.0) / size;
+	double expected_null_threshold = utf16_expected_null_percent_ / 100.0;
+	double unexpected_null_threshold = utf16_unexpected_null_percent_ / 100.0;
+
+	// Lots of odd nulls, low number of even nulls
+	if (even_null_threshold < unexpected_null_threshold	&& odd_null_threshold > expected_null_threshold)
+		return UTF16_LE_NOBOM;
+
+	// Lots of even nulls, low number of odd nulls
+	if (odd_null_threshold < unexpected_null_threshold && even_null_threshold > expected_null_threshold)
+		return UTF16_BE_NOBOM;
+
+	// Don't know
+	return None;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Checks if a buffer contains any nulls. Used to check for binary vs text data.
+///////////////////////////////////////////////////////////////////////////////
+
+bool TextEncodingDetect::DoesContainNulls(const unsigned char *pBuffer, size_t size)
+{
+	size_t pos = 0;
+	while (pos < size)
+	{
+		if (pBuffer[pos++] == 0)
+			return true;
+	}
+
+	return false;
+}

--- a/Source/text_encoding_detect.h
+++ b/Source/text_encoding_detect.h
@@ -1,0 +1,78 @@
+#pragma once
+#ifndef TEXT_ENCODING_DETECT_H_
+#define TEXT_ENCODING_DETECT_H_
+
+//
+// Copyright 2015 Jonathan Bennett <jon@autoitscript.com>
+// 
+// https://www.autoitscript.com 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// 
+
+// Includes
+#include <stddef.h>
+
+namespace TextEncoding
+{ 
+	class TextEncodingDetect
+	{
+	public:
+		enum Encoding
+		{
+			None,				// Unknown or binary
+			ANSI,				// 0-255
+			ASCII,				// 0-127
+			UTF8_BOM,			// UTF8 with BOM
+			UTF8_NOBOM,			// UTF8 without BOM
+			UTF16_LE_BOM,		// UTF16 LE with BOM
+			UTF16_LE_NOBOM,		// UTF16 LE without BOM
+			UTF16_BE_BOM,		// UTF16-BE with BOM
+			UTF16_BE_NOBOM,		// UTF16-BE without BOM
+		};
+
+		TextEncodingDetect();
+		~TextEncodingDetect();
+
+		static Encoding CheckBOM(const unsigned char *pBuffer, size_t size);		// Just check if there is a BOM and return 
+		Encoding DetectEncoding(const unsigned char *pBuffer, size_t size) const;	// Check BOM and also guess if there is no BOM
+		static int GetBOMLengthFromEncodingMode(Encoding encoding);			// Just return the BOM length of a given mode
+
+        Encoding CheckUTF8(const unsigned char* pBuffer, size_t size) const;				// Check for valid UTF8 with no BOM
+        Encoding CheckUTF16ASCII(const unsigned char* pBuffer, size_t size) const;		// Check for valid UTF16 with no BOM via null distribution
+
+		void SetNullSuggestsBinary(bool null_suggests_binary) { null_suggests_binary_ = null_suggests_binary; }
+		void SetUtf16UnexpectedNullPercent(int percent);
+		void SetUtf16ExpectedNullPercent(int percent);
+
+	private:
+		TextEncodingDetect(const TextEncodingDetect&);
+		const TextEncodingDetect& operator=(const TextEncodingDetect&);
+
+		static const unsigned char* utf16_bom_le_;
+		static const unsigned char* utf16_bom_be_;
+		static const unsigned char* utf8_bom_;
+
+		bool	null_suggests_binary_;
+		int		utf16_expected_null_percent_;
+		int		utf16_unexpected_null_percent_;
+
+		static Encoding CheckUTF16NewlineChars(const unsigned char *pBuffer, size_t size);	// Check for valid UTF16 with no BOM via control chars
+		static bool DoesContainNulls(const unsigned char *pBuffer, size_t size);			// Check for nulls
+	};
+
+} // TextEncoding
+
+//////////////////////////////////////////////////////////////////////
+
+#endif


### PR DESCRIPTION
This is to solve #367 

I also added conversion from UTF16BE/LE to UTF8, if we detect that encoding (never ever seen that on a sub, but anyways).