### PR TITLE
Ensure consistency between VS and command line builds

### DIFF
--- a/Build-FFmpegInteropX.ps1
+++ b/Build-FFmpegInteropX.ps1
@@ -60,9 +60,6 @@ function Build-Platform {
 
     $PSBoundParameters | Out-String
 
-    $hostArch = ( 'x86', 'x64' )[ [System.Environment]::Is64BitOperatingSystem ]
-    $targetArch = $Platform.ToLower()
-
     Write-Host
     Write-Host "Building FFmpegInteropX for Windows 10 ${Platform}..."
     Write-Host
@@ -72,8 +69,7 @@ function Build-Platform {
 
     Enter-VsDevShell `
         -VsInstallPath $VsLatestPath `
-        -StartInPath "$PWD" `
-        -DevCmdArguments "-arch=$targetArch -host_arch=$hostArch -winsdk=$WindowsTargetPlatformVersion -vcvars_ver=$VcVersion -app_platform=UWP"
+        -StartInPath "$PWD"
 
     if ($ClearBuildFolders) {
         # Clean platform-specific build and output dirs.
@@ -86,8 +82,7 @@ function Build-Platform {
         /p:Configuration=${Configuration}_${WindowsTarget} `
         /p:Platform=$Platform `
         /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
-        /p:PlatformToolset=$PlatformToolset `
-        /p:useenv=true
+        /p:PlatformToolset=$PlatformToolset
 
     if ($lastexitcode -ne 0) { throw "Failed to build library FFmpegInteropX.vcxproj." }
 
@@ -98,8 +93,7 @@ function Build-Platform {
             /t:FFmpegInteropX_DotNet `
             /p:Configuration=${Configuration}_${WindowsTarget} `
             /p:Platform=$Platform `
-            /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
-            /p:useenv=true
+            /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion
 
         if ($lastexitcode -ne 0) { throw "Failed to build library FFmpegInteropX.DotNet.csproj." }
     }


### PR DESCRIPTION
I finally identified the culprit which is responsible for a significant amount of pain I've gone through.

The use of the devcmd parameters in the PowerShell command have the effect that you get different results between builds made in Visual Studio and builds via `Build-FFmpegInteropX.ps1`.

Especially the `app_platform=UWP` settings does some very obscure things. It seems to trigger some outdated MSBuild functionality which overrides settings in the .vcxproj.

But all of those parameters must be dropped. I don't think that any of this is needed at all, but in case it would, then it would need to be replicated in the .vcxproj. 

When doing a build in VS and you get a different result from a command line build, then it's pointless to even work an anything (sorry for sounding harsh, this has just cost me lots of hours).

Besides all the confusion this has caused for me, it is also responsible for the <DesktopCompatible> setting to have no effect, which in turn is the cause why your WinUI package wasn't working properly (because it still referenced app-local runtime dlls).