### PR TITLE
Replace forbidden APIs and remove appcontainer conditions

### DIFF
--- a/Source/FFmpegInteropX.vcxproj
+++ b/Source/FFmpegInteropX.vcxproj
@@ -27,9 +27,9 @@
     <RootNamespace>FFmpegInteropX</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <AppContainerApplication Condition="'$(AppType)'=='UWP'">true</AppContainerApplication>
-    <ApplicationType Condition="'$(AppType)'=='UWP'">Windows Store</ApplicationType>
-    <ApplicationTypeRevision Condition="'$(AppType)'=='UWP'">10.0</ApplicationTypeRevision>
+    <AppContainerApplication>true</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -1860,25 +1860,10 @@ namespace winrt::FFmpegInteropX::implementation
                 try
                 {
 #ifdef WinUI
-                    if (windowId == 0)
-                    {
-                        HWND handle = NULL;
-                        HWND* pHandle = &handle;
-                        static auto callback = [](HWND hwnd, LPARAM param)
-                            {
-                                if (GetParent(hwnd) == NULL)
-                                {
-                                    *((HWND*)param) = hwnd;
-                                    return FALSE;
-                                }
-                                return TRUE;
-                            };
-                        EnumThreadWindows(GetCurrentThreadId(), callback, (LPARAM)pHandle);
-                        if (handle)
-                        {
-                            windowId = Microsoft::UI::GetWindowIdFromWindow(handle).Value;
-                        }
-                    }
+                    ////if (windowId == 0)
+                    ////{
+                    ////    windowId = Microsoft::UI::Xaml::Window::Current().AppWindow().Id().Value;
+                    ////}
 
                     if (windowId)
                     {


### PR DESCRIPTION
All C++/WinRT components must set these build variables, it's not only for UWP components.

They were probably disabled conditionally to make it compile with those user32.dll functions (`EnumThreadWindows` etc.), but - afaik - these are still not allowed to use from a packaged app. 
Not setting those variables may also have side effects on projection generation and consumption, so let's better avoid this in the first place.