### PR TITLE
Use proper platform targeting

### DIFF
--- a/Build-FFmpegInteropX.ps1
+++ b/Build-FFmpegInteropX.ps1
@@ -15,15 +15,6 @@ param(
     #>
     [version] $VcVersion = '14.3',
 
-    <#
-        Example values:
-        8.1
-        10.0.15063.0
-        10.0.17763.0
-        10.0.18362.0
-    #>
-    [version] $WindowsTargetPlatformVersion = '10.0.22000.0',
-
     [ValidateSet('UWP', 'WinUI', 'Desktop')]
     [string] $WindowsTarget = 'UWP',
 
@@ -73,7 +64,7 @@ function Build-Platform {
     Enter-VsDevShell `
         -VsInstallPath $VsLatestPath `
         -StartInPath "$PWD" `
-        -DevCmdArguments "-arch=$targetArch -host_arch=$hostArch -winsdk=$WindowsTargetPlatformVersion -vcvars_ver=$VcVersion -app_platform=UWP"
+        -DevCmdArguments "-arch=$targetArch -host_arch=$hostArch -vcvars_ver=$VcVersion -app_platform=UWP"
 
     if ($ClearBuildFolders) {
         # Clean platform-specific build and output dirs.
@@ -85,7 +76,6 @@ function Build-Platform {
         /restore `
         /p:Configuration=${Configuration}_${WindowsTarget} `
         /p:Platform=$Platform `
-        /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
         /p:PlatformToolset=$PlatformToolset `
         /p:useenv=true
 
@@ -98,7 +88,6 @@ function Build-Platform {
             /t:FFmpegInteropX_DotNet `
             /p:Configuration=${Configuration}_${WindowsTarget} `
             /p:Platform=$Platform `
-            /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
             /p:useenv=true
 
         if ($lastexitcode -ne 0) { throw "Failed to build library FFmpegInteropX.DotNet.csproj." }
@@ -160,7 +149,7 @@ if ($AllowParallelBuilds -and $Platforms.Count -gt 1)
             continue;
         }
 
-        $proc = Start-Process -PassThru powershell "-File .\Build-FFmpegInteropX.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -Configuration $Configuration -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -FFmpegInteropXUrl ""$FFmpegInteropXUrl"" -FFmpegInteropXBranch ""FFmpegInteropXBranch"" -FFmpegInteropXCommit ""$FFmpegInteropXCommit"" $addparams"
+        $proc = Start-Process -PassThru powershell "-File .\Build-FFmpegInteropX.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -Configuration $Configuration -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -FFmpegInteropXUrl ""$FFmpegInteropXUrl"" -FFmpegInteropXBranch ""FFmpegInteropXBranch"" -FFmpegInteropXCommit ""$FFmpegInteropXCommit"" $addparams"
         $processes[$platform] = $proc
     }
 

--- a/Build/FFmpegInteropX.Desktop.nuspec
+++ b/Build/FFmpegInteropX.Desktop.nuspec
@@ -9,7 +9,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <dependencies>
-      <group targetFramework="net6.0-windows10.0.17763.0">
+      <group targetFramework="net6.0-windows10.0.22000.0">
         <dependency id="FFmpegInteropX.FFmpegUWP" version="5.1.100" />
       </group>
       <group targetFramework="native" />
@@ -18,8 +18,8 @@
   </metadata>
   <files>
 
-    <file src="..\Output\FFmpegInteropX.DotNet\Release_Desktop\FFmpegInteropX.DotNet.dll"  target="lib\net6.0-windows10.0.17763.0" />
-    <file src="..\Output\FFmpegInteropX.DotNet\Release_Desktop\FFmpegInteropX.xml"         target="lib\net6.0-windows10.0.17763.0" />
+    <file src="..\Output\FFmpegInteropX.DotNet\Release_Desktop\FFmpegInteropX.DotNet.dll"  target="lib\net6.0-windows10.0.22000.0" />
+    <file src="..\Output\FFmpegInteropX.DotNet\Release_Desktop\FFmpegInteropX.xml"         target="lib\net6.0-windows10.0.22000.0" />
     
     <file src="..\Output\FFmpegInteropX\x86\Release_Desktop\FFmpegInteropX.dll"     target="runtimes\win10-x86\native" />
     <file src="..\Output\FFmpegInteropX\x86\Release_Desktop\FFmpegInteropX.pdb"     target="runtimes\win10-x86\native" />

--- a/Build/FFmpegInteropX.Desktop.targets
+++ b/Build/FFmpegInteropX.Desktop.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\net6.0-windows10.0.17763.\FFmpegInteropX.dll" />
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\net6.0-windows10.0.22000.\FFmpegInteropX.dll" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(PlatformTarget)\native\*.dll" />
   </ItemGroup>
 </Project>

--- a/Build/FFmpegInteropX.WinUI.nuspec
+++ b/Build/FFmpegInteropX.WinUI.nuspec
@@ -9,7 +9,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <dependencies>
-      <group targetFramework="net6.0-windows10.0.17763.0">
+      <group targetFramework="net6.0-windows10.0.22000.0">
         <dependency id="FFmpegInteropX.FFmpegUWP" version="5.1.100" />
         <dependency id="Microsoft.WindowsAppSDK" version="1.4.230913002" />
       </group>
@@ -22,8 +22,8 @@
   </metadata>
   <files>
 
-    <file src="..\Output\FFmpegInteropX.DotNet\Release_WinUI\FFmpegInteropX.DotNet.dll"  target="lib\net6.0-windows10.0.17763.0" />
-    <file src="..\Output\FFmpegInteropX.DotNet\Release_WinUI\FFmpegInteropX.xml"         target="lib\net6.0-windows10.0.17763.0" />
+    <file src="..\Output\FFmpegInteropX.DotNet\Release_WinUI\FFmpegInteropX.DotNet.dll"  target="lib\net6.0-windows10.0.22000.0" />
+    <file src="..\Output\FFmpegInteropX.DotNet\Release_WinUI\FFmpegInteropX.xml"         target="lib\net6.0-windows10.0.22000.0" />
     
     <file src="..\Output\FFmpegInteropX\x86\Release_WinUI\FFmpegInteropX.dll"     target="runtimes\win10-x86\native" />
     <file src="..\Output\FFmpegInteropX\x86\Release_WinUI\FFmpegInteropX.pdb"     target="runtimes\win10-x86\native" />

--- a/Build/FFmpegInteropX.WinUI.targets
+++ b/Build/FFmpegInteropX.WinUI.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\net6.0-windows10.0.17763.\FFmpegInteropX.dll" />
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\net6.0-windows10.0.22000.\FFmpegInteropX.dll" />
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(PlatformTarget)\native\*.dll" />
   </ItemGroup>
 </Project>

--- a/Source/FFmpegInteropX.vcxproj
+++ b/Source/FFmpegInteropX.vcxproj
@@ -30,7 +30,7 @@
     <AppContainerApplication Condition="'$(AppType)'=='UWP'">true</AppContainerApplication>
     <ApplicationType Condition="'$(AppType)'=='UWP'">Windows Store</ApplicationType>
     <ApplicationTypeRevision Condition="'$(AppType)'=='UWP'">10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <UseWinUI>true</UseWinUI>
     <CppWinRTModernIDL>true</CppWinRTModernIDL>


### PR DESCRIPTION
The vcxproj targets 22000. 
The .Dotnet projection project is referencing it, so it must target 22000 at minimum (you can see an error when building in VS when trying otherwise).
Any other project which references the .Dotnet project in turn, needs to target 22000 at minimum as well. 
That's no different when the referencing is going through a nuget package, and that means that the nuget package needs to require 22000 accordingly.  This PR sets the numbers in the nuspec files correctly.

Another conclusion from this is that there's not really a choice for the targeting versions. The required version is determined by the features which are being used in the vcxproj. A lower version cannot be used, and there's no reason to use a higher version. 
In turn, there's no point in making this a choice in the PS build script. Even if this would still be desired, it would have to be changed in a way that the selection from `Build-FFmpegInteropX.ps1` would not only need to be set in the vcxproj, but also in the projection projection, in the nuspec files and the corresponding targets files.

This PR removes the selection from the build script and hardcodes it in the vcxproj.




