### PR TITLE
Fix nuget sdk versions and build script sdk versions

### DIFF
--- a/Build-FFmpegInteropX.ps1
+++ b/Build-FFmpegInteropX.ps1
@@ -99,6 +99,7 @@ function Build-Platform {
             /p:Configuration=${Configuration}_${WindowsTarget} `
             /p:Platform=$Platform `
             /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+            /p:TargetFramework="net6.0-windows$WindowsTargetPlatformVersion" `
             /p:useenv=true
 
         if ($lastexitcode -ne 0) { throw "Failed to build library FFmpegInteropX.DotNet.csproj." }
@@ -229,7 +230,7 @@ else
 if ($success -and $NugetPackageVersion)
 {
     nuget pack .\Build\FFmpegInteropX.$WindowsTarget.nuspec `
-        -Properties "id=FFmpegInteropX.$WindowsTarget;repositoryUrl=$FFmpegInteropXUrl;repositoryBranch=$FFmpegInteropXBranch;repositoryCommit=$FFmpegInteropXCommit;NoWarn=NU5128" `
+        -Properties "id=FFmpegInteropX.$WindowsTarget;repositoryUrl=$FFmpegInteropXUrl;repositoryBranch=$FFmpegInteropXBranch;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformVersion;NoWarn=NU5128" `
         -Version $NugetPackageVersion `
         -Symbols -SymbolPackageFormat symbols.nupkg `
         -OutputDirectory "Output\NuGet"

--- a/Build/FFmpegInteropX.Desktop.nuspec
+++ b/Build/FFmpegInteropX.Desktop.nuspec
@@ -18,6 +18,9 @@
     <repository type="git" url="$repositoryUrl$" branch="$repositoryBranch$" commit="$repositoryCommit$" />
   </metadata>
   <files>
+    
+    <file src="..\Output\FFmpegInteropX\x64\Release_Desktop\FFmpegInteropX.winmd"   target="lib\uap10.0" />
+    <file src="..\Output\FFmpegInteropX\x64\Release_Desktop\FFmpegInteropX.xml"     target="lib\uap10.0" />
 
     <file src="..\Output\FFmpegInteropX.DotNet\Release_Desktop\FFmpegInteropX.DotNet.dll"  target="lib\net6.0-windows$winsdk$" />
     <file src="..\Output\FFmpegInteropX.DotNet\Release_Desktop\FFmpegInteropX.xml"         target="lib\net6.0-windows$winsdk$" />

--- a/Build/FFmpegInteropX.Desktop.nuspec
+++ b/Build/FFmpegInteropX.Desktop.nuspec
@@ -9,8 +9,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <dependencies>
-      <group targetFramework="net6.0-windows10.0.17763.0">
+      <group targetFramework="net6.0-windows$winsdk$">
         <dependency id="FFmpegInteropX.FFmpegUWP" version="5.1.100" />
+        <dependency id="Microsoft.Windows.CsWinRT" version="2.0" />
       </group>
       <group targetFramework="native" />
     </dependencies>
@@ -18,8 +19,8 @@
   </metadata>
   <files>
 
-    <file src="..\Output\FFmpegInteropX.DotNet\Release_Desktop\FFmpegInteropX.DotNet.dll"  target="lib\net6.0-windows10.0.17763.0" />
-    <file src="..\Output\FFmpegInteropX.DotNet\Release_Desktop\FFmpegInteropX.xml"         target="lib\net6.0-windows10.0.17763.0" />
+    <file src="..\Output\FFmpegInteropX.DotNet\Release_Desktop\FFmpegInteropX.DotNet.dll"  target="lib\net6.0-windows$winsdk$" />
+    <file src="..\Output\FFmpegInteropX.DotNet\Release_Desktop\FFmpegInteropX.xml"         target="lib\net6.0-windows$winsdk$" />
     
     <file src="..\Output\FFmpegInteropX\x86\Release_Desktop\FFmpegInteropX.dll"     target="runtimes\win10-x86\native" />
     <file src="..\Output\FFmpegInteropX\x86\Release_Desktop\FFmpegInteropX.pdb"     target="runtimes\win10-x86\native" />

--- a/Build/FFmpegInteropX.Desktop.targets
+++ b/Build/FFmpegInteropX.Desktop.targets
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\net6.0-windows10.0.17763.\FFmpegInteropX.dll" />
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\FFmpegInteropX.winmd">
+      <Implementation>FFmpegInteropX.dll</Implementation>
+    </Reference>
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(PlatformTarget)\native\*.dll" />
   </ItemGroup>
 </Project>

--- a/Build/FFmpegInteropX.WinUI.nuspec
+++ b/Build/FFmpegInteropX.WinUI.nuspec
@@ -9,9 +9,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <dependencies>
-      <group targetFramework="net6.0-windows10.0.17763.0">
+      <group targetFramework="net6.0-windows$winsdk$">
         <dependency id="FFmpegInteropX.FFmpegUWP" version="5.1.100" />
         <dependency id="Microsoft.WindowsAppSDK" version="1.4.230913002" />
+        <dependency id="Microsoft.Windows.CsWinRT" version="2.0" />
       </group>
       <group targetFramework="native">
         <dependency id="FFmpegInteropX.FFmpegUWP" version="5.1.100" />
@@ -22,8 +23,8 @@
   </metadata>
   <files>
 
-    <file src="..\Output\FFmpegInteropX.DotNet\Release_WinUI\FFmpegInteropX.DotNet.dll"  target="lib\net6.0-windows10.0.17763.0" />
-    <file src="..\Output\FFmpegInteropX.DotNet\Release_WinUI\FFmpegInteropX.xml"         target="lib\net6.0-windows10.0.17763.0" />
+    <file src="..\Output\FFmpegInteropX.DotNet\Release_WinUI\FFmpegInteropX.DotNet.dll"  target="lib\net6.0-windows$winsdk$" />
+    <file src="..\Output\FFmpegInteropX.DotNet\Release_WinUI\FFmpegInteropX.xml"         target="lib\net6.0-windows$winsdk$" />
     
     <file src="..\Output\FFmpegInteropX\x86\Release_WinUI\FFmpegInteropX.dll"     target="runtimes\win10-x86\native" />
     <file src="..\Output\FFmpegInteropX\x86\Release_WinUI\FFmpegInteropX.pdb"     target="runtimes\win10-x86\native" />

--- a/Build/FFmpegInteropX.WinUI.nuspec
+++ b/Build/FFmpegInteropX.WinUI.nuspec
@@ -23,6 +23,9 @@
   </metadata>
   <files>
 
+    <file src="..\Output\FFmpegInteropX\x64\Release_WinUI\FFmpegInteropX.winmd"   target="lib\uap10.0" />
+    <file src="..\Output\FFmpegInteropX\x64\Release_WinUI\FFmpegInteropX.xml"     target="lib\uap10.0" />
+
     <file src="..\Output\FFmpegInteropX.DotNet\Release_WinUI\FFmpegInteropX.DotNet.dll"  target="lib\net6.0-windows$winsdk$" />
     <file src="..\Output\FFmpegInteropX.DotNet\Release_WinUI\FFmpegInteropX.xml"         target="lib\net6.0-windows$winsdk$" />
     

--- a/Build/FFmpegInteropX.WinUI.targets
+++ b/Build/FFmpegInteropX.WinUI.targets
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\net6.0-windows10.0.17763.\FFmpegInteropX.dll" />
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\FFmpegInteropX.winmd">
+      <Implementation>FFmpegInteropX.dll</Implementation>
+    </Reference>
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win10-$(PlatformTarget)\native\*.dll" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is an improved version of #382.
- Fix NuGet Windows SDK versions
- Fix build script not setting DotNet TargetFramework correctly
- Add CsWinRT as dependency for .net WinUI/Desktop targets