### PR TITLE
ASS Subtitle Fixes

### DIFF
--- a/Source/SubtitleProvider.h
+++ b/Source/SubtitleProvider.h
@@ -193,6 +193,11 @@ public:
 
     int parseHexOrDecimalInt(std::wstring const& str, size_t offset)
     {
+        if (offset > 2 && str[offset - 2] == L'H' && str[offset - 1] == L'&')
+        {
+            // Fix for cases where colors are specified like: 3cH&H2A4F5D&
+            offset++;
+        }
         if (str.length() > offset + 1 && str[offset] == L'H')
         {
             return parseHexInt(str.substr(offset + 1));

--- a/Source/SubtitleProviderSsaAss.h
+++ b/Source/SubtitleProviderSsaAss.h
@@ -601,14 +601,14 @@ public:
                 int bold, italic, underline, strikeout;
                 float scaleX, scaleY, spacing, angle;
                 int borderStyle;
-                float outline;
-                int shadow, alignment;
+                float outline, shadow;
+                int alignment;
                 float marginL, marginR, marginV;
                 int encoding;
 
                 // try with hex colors
                 auto count = sscanf_s((char*)m_pAvCodecCtx->subtitle_header + stylesV4plus,
-                    "%[^,],%[^,],%f,&H%x,&H%x,&H%x,&H%x,%i,%i,%i,%i,%f,%f,%f,%f,%i,%f,%i,%i,%f,%f,%f,%i",
+                    "%[^,],%[^,],%f,&H%x,&H%x,&H%x,&H%x,%i,%i,%i,%i,%f,%f,%f,%f,%i,%f,%f,%i,%f,%f,%f,%i",
                     name, MAX_STYLE_NAME_CHARS, font, MAX_STYLE_NAME_CHARS,
                     &size, &color, &secondaryColor, &outlineColor, &backColor,
                     &bold, &italic, &underline, &strikeout,
@@ -620,7 +620,7 @@ public:
                 {
                     // try with decimal colors
                     count = sscanf_s((char*)m_pAvCodecCtx->subtitle_header + stylesV4plus,
-                        "%[^,],%[^,],%f,%i,%i,%i,%i,%i,%i,%i,%i,%f,%f,%f,%f,%i,%f,%i,%i,%f,%f,%f,%i",
+                        "%[^,],%[^,],%f,%i,%i,%i,%i,%i,%i,%i,%i,%f,%f,%f,%f,%i,%f,%f,%i,%f,%f,%f,%i",
                         name, MAX_STYLE_NAME_CHARS, font, MAX_STYLE_NAME_CHARS,
                         &size, &color, &secondaryColor, &outlineColor, &backColor,
                         &bold, &italic, &underline, &strikeout,

--- a/Source/SubtitleProviderSsaAss.h
+++ b/Source/SubtitleProviderSsaAss.h
@@ -67,6 +67,7 @@ public:
 
                 if (resy != str.npos && sscanf_s((char*)m_pAvCodecCtx->subtitle_header + resy, "\nPlayResY: %i\n", &h) == 1)
                 {
+                    hasPlayResY = true;
                     height = h;
                 }
 
@@ -990,8 +991,17 @@ public:
     TimedTextDouble GetFontSize(double fontSize)
     {
         TimedTextDouble size;
-        size.Unit = TimedTextUnit::Percentage;
-        size.Value = fontSize * 2.7;
+
+        if (hasPlayResY && videoHeight > 0 && height > 0)
+        {
+            size.Unit = TimedTextUnit::Pixels;
+            size.Value = static_cast<double>(videoHeight) / height * fontSize * 0.85;
+        }
+        else
+        {
+            size.Unit = TimedTextUnit::Percentage;
+            size.Value = fontSize * 2.7;
+        }
 
         return size;
     }
@@ -1064,6 +1074,7 @@ private:
     int textIndex = 0;
     int width = 0;
     int height = 0;
+    bool hasPlayResY = false;
     double videoAspectRatio = 0.0;
     int videoWidth = 0;
     int videoHeight = 0;

--- a/Source/SubtitleProviderSsaAss.h
+++ b/Source/SubtitleProviderSsaAss.h
@@ -589,7 +589,7 @@ public:
         }
         else if (result <= 0)
         {
-            OutputDebugString(L"Failed to decode subtitle.");
+            OutputDebugString(L"Failed to decode subtitle.\r\n");
         }
 
         return nullptr;

--- a/Source/SubtitleProviderSsaAss.h
+++ b/Source/SubtitleProviderSsaAss.h
@@ -438,7 +438,8 @@ public:
                                 }
                                 catch (...)
                                 {
-                                    OutputDebugString(L"Failed to parse tag: ");
+                                    std::wstring output = L"Failed to parse tag: " + tag + L"\r\n";
+                                    OutputDebugString(output.c_str());
                                 }
                             }
 

--- a/Source/SubtitleProviderSsaAss.h
+++ b/Source/SubtitleProviderSsaAss.h
@@ -293,6 +293,14 @@ public:
                                             subStyle.FontFamily(GetFontFamily(fnName));
                                         }
                                     }
+                                    else if (checkTag(tag, L"fsc"))
+                                    {
+                                        // TODO: \fsc<x or y><percent>	<x or y> x scales horizontally, y scales vertically <percent>
+                                    }
+                                    else if (checkTag(tag, L"fsp"))
+                                    {
+                                        // TODO: \fsp<pixels>		    <pixels> changes the distance between letters. (default: 0)
+                                    }
                                     else if (checkTag(tag, L"fs"))
                                     {
                                         auto size = parseDouble(tag.substr(2));
@@ -300,6 +308,11 @@ public:
                                         {
                                             subStyle.FontSize(GetFontSize(size));
                                         }
+                                    }
+                                    else if (checkTag(tag, L"clip"))
+                                    {
+                                        // TODO: \clip(<x1>, <y1>, <x2>, <y2>)    Clips any drawing outside the rectangle defined by the parameters.
+                                        //       \clip([<scale>,] <drawing commands>) Clipping against drawn shapes.  <scale> has the same meaning as in the case of \p<scale>
                                     }
                                     else if (checkTag(tag, L"c", 2))
                                     {


### PR DESCRIPTION
SubtitleProviderSsaAss: Add line break
SubtitleProviderSsaAss: Calc font size
SubtitleProviderSsaAss: Print offending tag in case of parsing errors
SubtitleProviderSsaAss: Prevent parsing errors due to ambiguous tags
SubtitleProvider: Fix for color strings like H&H2A4F5D&
SubtitleProviderSsaAss: Shadow is float

Fixes #397