### PR TITLE
External subtitle parser

### DIFF
--- a/Samples/MediaPlayerCPP/MainPage.xaml
+++ b/Samples/MediaPlayerCPP/MainPage.xaml
@@ -80,6 +80,7 @@
                         </ComboBox>
 
                         <Button Content="Load External Subtitle File (ffmpeg)" Click="LoadSubtitleFileFFmpeg"  Margin="0,20,10,10" />
+                        <Button Content="Read External Subtitle File (ffmpeg)" Click="ReadSubtitleFileFFmpeg"  Margin="0,20,10,10" />
                         <Button Content="Load External Subtitle File (winAPI)" Click="LoadSubtitleFile"  Margin="0,20,10,10" />
 
                         <TextBlock x:Name="tbSubtitleDelay" Text="Subtitle delay: 0s" Margin="0,20,0,5"/>

--- a/Samples/MediaPlayerCPP/MainPage.xaml.cpp
+++ b/Samples/MediaPlayerCPP/MainPage.xaml.cpp
@@ -70,7 +70,7 @@ MainPage::MainPage()
     cbEncodings->ItemsSource = CharacterEncoding::AllEncodings;
 
     Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyDown += ref new Windows::Foundation::TypedEventHandler<Windows::UI::Core::CoreWindow^, Windows::UI::Core::KeyEventArgs^>(this, &MediaPlayerCPP::MainPage::OnKeyDown);
-    
+
     StreamDelays->AddHandler(UIElement::PointerReleasedEvent, ref new PointerEventHandler(this, &MainPage::StreamDelayManipulation), true);
 }
 
@@ -203,7 +203,7 @@ task<void> MainPage::OpenUriStream(Platform::String^ uri)
     // https://www.ffmpeg.org/ffmpeg-formats.html
     // 
     // If format cannot be detected, try to increase probesize, max_probe_packets and analyzeduration!
-    
+
     // Below are some sample options that you can set to configure RTSP streaming
     //Config->FFmpegOptions->Insert("rtsp_flags", "prefer_tcp");
     Config->FFmpegOptions->Insert("stimeout", 1000000);
@@ -421,7 +421,7 @@ void MediaPlayerCPP::MainPage::OnMediaFailed(Windows::Media::Playback::MediaPlay
         ref new Windows::UI::Core::DispatchedHandler([this, args]
             {
                 auto message = args->ErrorMessage;
-                if ((!message || message->Length() == 0)) 
+                if ((!message || message->Length() == 0))
                 {
                     message = args->ExtendedErrorCode.ToString();
                 }
@@ -559,7 +559,7 @@ void MediaPlayerCPP::MainPage::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, 
         return;
     }
 
-    if (args->VirtualKey == Windows::System::VirtualKey::V && (Window::Current->CoreWindow->GetKeyState(Windows::System::VirtualKey::Control) == Windows::UI::Core::CoreVirtualKeyStates:: None))
+    if (args->VirtualKey == Windows::System::VirtualKey::V && (Window::Current->CoreWindow->GetKeyState(Windows::System::VirtualKey::Control) == Windows::UI::Core::CoreVirtualKeyStates::None))
     {
         auto playbackItem = FFmpegMSS ? FFmpegMSS->PlaybackItem : nullptr;
         if (playbackItem && playbackItem->VideoTracks->Size > 1)
@@ -652,10 +652,42 @@ void MediaPlayerCPP::MainPage::ffmpegAudioFilters_KeyDown(Platform::Object^ send
 
 double MediaPlayerCPP::MainPage::GetBufferSizeMB()
 {
-    return (double)Config->General->ReadAheadBufferSize / (1024*1024);
+    return (double)Config->General->ReadAheadBufferSize / (1024 * 1024);
 }
 
 void MediaPlayerCPP::MainPage::SetBufferSizeMB(double value)
 {
     Config->General->ReadAheadBufferSize = (long long)(value * (1024 * 1024));
+}
+
+
+void MediaPlayerCPP::MainPage::ReadSubtitleFileFFmpeg(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+    ReadSubtitleFileFFmpegImpl();
+}
+
+task<void> MediaPlayerCPP::MainPage::ReadSubtitleFileFFmpegImpl()
+{
+    try
+    {
+        FileOpenPicker^ filePicker = ref new FileOpenPicker();
+        filePicker->SettingsIdentifier = "SubtitleFile";
+        filePicker->ViewMode = PickerViewMode::Thumbnail;
+        filePicker->SuggestedStartLocation = PickerLocationId::VideosLibrary;
+        filePicker->FileTypeFilter->Append("*");
+
+        // Show file picker so user can select a file
+        auto file = co_await filePicker->PickSingleFileAsync();
+        if (file != nullptr)
+        {
+            // Open StorageFile as IRandomAccessStream to be passed to FFmpegMediaSource
+            auto stream = co_await file->OpenAsync(FileAccessMode::Read);
+            auto subParser = co_await SubtitleParser::ReadSubtitleAsync(stream);
+            DisplayErrorMessage("File contains " + subParser->SubtitleTrack->SubtitleTrack->Cues->Size.ToString() + " cues");
+        }
+    }
+    catch (Exception^ e)
+    {
+        DisplayErrorMessage(e->Message);
+    }
 }

--- a/Samples/MediaPlayerCPP/MainPage.xaml.h
+++ b/Samples/MediaPlayerCPP/MainPage.xaml.h
@@ -87,5 +87,7 @@ namespace MediaPlayerCPP
         void OnMediaFailed(Windows::Media::Playback::MediaPlayer^ sender, Windows::Media::Playback::MediaPlayerFailedEventArgs^ args);
 
         void StreamDelayManipulation(Platform::Object^ sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e);
+        void ReadSubtitleFileFFmpeg(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        task<void> ReadSubtitleFileFFmpegImpl();
     };
 }

--- a/Samples/MediaPlayerCS/MainPage.xaml
+++ b/Samples/MediaPlayerCS/MainPage.xaml
@@ -83,6 +83,7 @@
                         </ComboBox>
 
                         <Button Content="Load External Subtitle File (ffmpeg)" Click="LoadSubtitleFileFFmpeg"  Margin="0,20,10,10" />
+                        <Button Content="Read External Subtitle File (ffmpeg)" Click="ReadSubtitleFileFFmpeg"  Margin="0,20,10,10" />
                         <Button Content="Load External Subtitle File (winAPI)" Click="LoadSubtitleFile"  Margin="0,20,10,10" />
 
                         <TextBlock x:Name="tbSubtitleDelay" Text="Subtitle delay: 0s" Margin="0,20,0,5"/>

--- a/Samples/MediaPlayerCS/MainPage.xaml.cs
+++ b/Samples/MediaPlayerCS/MainPage.xaml.cs
@@ -263,7 +263,7 @@ namespace MediaPlayerCS
 
             // Open with MediaPlayer
             await FFmpegMSS.OpenWithMediaPlayerAsync(mediaPlayer);
-            
+
             // Close control panel after file open
             Splitter.IsPaneOpen = false;
         }
@@ -591,12 +591,12 @@ namespace MediaPlayerCS
                     cmbVideoStreamEffectSelector.ItemsSource = FFmpegMSS.VideoStreams;
 
                     List<IStreamInfo> streams = new List<IStreamInfo>();
-                    foreach(var a in FFmpegMSS.AudioStreams)
+                    foreach (var a in FFmpegMSS.AudioStreams)
                     {
                         streams.Add(a);
                     }
 
-                    foreach(var  vs in FFmpegMSS.VideoStreams)
+                    foreach (var vs in FFmpegMSS.VideoStreams)
                     {
                         streams.Add(vs);
                     }
@@ -689,6 +689,32 @@ namespace MediaPlayerCS
         private void GoToMediaPlaybackListSample(object sender, RoutedEventArgs e)
         {
             this.Frame.Navigate(typeof(MediaPlaybackListPage));
+        }
+
+        private async void ReadSubtitleFileFFmpeg(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                FileOpenPicker filePicker = new FileOpenPicker();
+                filePicker.SettingsIdentifier = "SubtitleFile";
+                filePicker.ViewMode = PickerViewMode.Thumbnail;
+                filePicker.SuggestedStartLocation = PickerLocationId.VideosLibrary;
+                filePicker.FileTypeFilter.Add("*");
+
+                // Show file picker so user can select a file
+                StorageFile file = await filePicker.PickSingleFileAsync();
+
+                if (file != null)
+                {
+                    var stream = await file.OpenReadAsync();
+                    var subParser = await SubtitleParser.ReadSubtitleAsync(stream);
+                    await DisplayErrorMessage($"Subtitle contains {subParser.SubtitleTrack.SubtitleTrack.Cues.Count} cues");
+                }
+            }
+            catch (Exception ex)
+            {
+                await DisplayErrorMessage(ex.ToString());
+            }
         }
     }
 }

--- a/Samples/MediaPlayerWinUI/MainPage.xaml
+++ b/Samples/MediaPlayerWinUI/MainPage.xaml
@@ -60,6 +60,7 @@
                         </ComboBox>
 
                         <Button Content="Load External Subtitle File (ffmpeg)" Click="LoadSubtitleFileFFmpeg"  Margin="0,20,10,10" />
+                        <Button Content="Read External Subtitle File (ffmpeg)" Click="ReadSubtitleFileFFmpeg"  Margin="0,20,10,10" />
                         <Button Content="Load External Subtitle File (winAPI)" Click="LoadSubtitleFile"  Margin="0,20,10,10" />
 
                         <TextBlock x:Name="tbSubtitleDelay" Text="Subtitle delay: 0s" Margin="0,20,0,5"/>

--- a/Samples/MediaPlayerWinUI/MainPage.xaml.cs
+++ b/Samples/MediaPlayerWinUI/MainPage.xaml.cs
@@ -657,5 +657,31 @@ namespace MediaPlayerWinUI
                 FFmpegMSS?.SetFFmpegAudioFilters(ffmpegAudioFilters.Text);
             else FFmpegMSS?.SetFFmpegAudioFilters(ffmpegAudioFilters.Text, (AudioStreamInfo)cmbAudioStreamEffectSelector.SelectedItem);
         }
+
+        private async void ReadSubtitleFileFFmpeg(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                FileOpenPicker filePicker = new FileOpenPicker();
+                filePicker.SettingsIdentifier = "SubtitleFile";
+                filePicker.ViewMode = PickerViewMode.Thumbnail;
+                filePicker.SuggestedStartLocation = PickerLocationId.VideosLibrary;
+                filePicker.FileTypeFilter.Add("*");
+
+                // Show file picker so user can select a file
+                StorageFile file = await filePicker.PickSingleFileAsync();
+
+                if (file != null)
+                {
+                    var stream = await file.OpenReadAsync();
+                    var subParser = await SubtitleParser.ReadSubtitleAsync(stream);
+                    DisplayErrorMessage($"Subtitle contains {subParser.SubtitleTrack.SubtitleTrack.Cues.Count} cues");
+                }
+            }
+            catch (Exception ex)
+            {
+                DisplayErrorMessage(ex.ToString());
+            }
+        }
     }
 }

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -603,25 +603,39 @@ namespace FFmpegInteropX
 
     runtimeclass SubtitleParser : Windows.Foundation.IClosable
     {
+        ///<summary>Returns the parsed subtitle track.</summary>
         SubtitleStreamInfo SubtitleTrack{get;};
 
+        [default_overload]
         ///<summary>Adds an external subtitle from a stream.</summary>
         ///<param name="stream">The subtitle stream.</param>
         ///<param name="streamName">The name to use for the subtitle.</param>
-        static Windows.Foundation.IAsyncOperation<SubtitleParser> ReadSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream, String streamName,
+        static Windows.Foundation.IAsyncOperation<SubtitleParser> ReadSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream,
+            String streamName,
             MediaSourceConfig config,
-            Windows.Media.Core.VideoStreamDescriptor videoDescriptor,
-            UInt64 windowId,
-            Boolean useHdr);
+            Windows.Media.Core.VideoStreamDescriptor videoDescriptor);
 
+        [default_overload]
         ///<summary>Adds an external subtitle from a stream.</summary>
         ///<param name="stream">The subtitle stream.</param>
         static Windows.Foundation.IAsyncOperation<SubtitleParser> ReadSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream);
 
-        ///<summary>Gets the presentation timestamp delay for the given stream. </summary>
+        ///<summary>Adds an external subtitle from an URI.</summary>
+        ///<param name="stream">The subtitle URI.</param>
+        ///<param name="streamName">The name to use for the subtitle.</param>
+        static Windows.Foundation.IAsyncOperation<SubtitleParser> ReadSubtitleAsync(Windows.Foundation.Uri uri,
+            String streamName,
+            MediaSourceConfig config,
+            Windows.Media.Core.VideoStreamDescriptor videoDescriptor);
+
+        ///<summary>Adds an external subtitle from an URI.</summary>
+        ///<param name="stream">The subtitle URI.</param>
+        static Windows.Foundation.IAsyncOperation<SubtitleParser> ReadSubtitleAsync(Windows.Foundation.Uri uri);
+
+        ///<summary>Gets the presentation timestamp delay for the subtitle stream. </summary>
         Windows.Foundation.TimeSpan GetStreamDelay();
 
-        ///<summary>Sets a presentation timestamp delay for the given stream. Audio, video and subtitle synchronisation can be achieved this way. A positive value will cause samples (or subtitles) to be rendered at a later time. A negative value will make rendering come sooner</summary>
+        ///<summary>Sets a presentation timestamp delay for the subtitle stream. Audio, video and subtitle synchronisation can be achieved this way. A positive value will cause samples (or subtitles) to be rendered at a later time. A negative value will make rendering come sooner</summary>
         void SetStreamDelay(Windows.Foundation.TimeSpan delay);
      }   
 

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -608,7 +608,11 @@ namespace FFmpegInteropX
         ///<summary>Adds an external subtitle from a stream.</summary>
         ///<param name="stream">The subtitle stream.</param>
         ///<param name="streamName">The name to use for the subtitle.</param>
-        static Windows.Foundation.IAsyncOperation<SubtitleParser> AddExternalSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream, String streamName);
+        static Windows.Foundation.IAsyncOperation<SubtitleParser> AddExternalSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream, String streamName,
+            MediaSourceConfig config,
+            Windows.Media.Core.VideoStreamDescriptor videoDescriptor,
+            UInt64 windowId,
+            Boolean useHdr);
 
         ///<summary>Adds an external subtitle from a stream.</summary>
         ///<param name="stream">The subtitle stream.</param>

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -608,7 +608,7 @@ namespace FFmpegInteropX
         ///<summary>Adds an external subtitle from a stream.</summary>
         ///<param name="stream">The subtitle stream.</param>
         ///<param name="streamName">The name to use for the subtitle.</param>
-        static Windows.Foundation.IAsyncOperation<SubtitleParser> AddExternalSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream, String streamName,
+        static Windows.Foundation.IAsyncOperation<SubtitleParser> ReadSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream, String streamName,
             MediaSourceConfig config,
             Windows.Media.Core.VideoStreamDescriptor videoDescriptor,
             UInt64 windowId,
@@ -616,7 +616,7 @@ namespace FFmpegInteropX
 
         ///<summary>Adds an external subtitle from a stream.</summary>
         ///<param name="stream">The subtitle stream.</param>
-        static Windows.Foundation.IAsyncOperation<SubtitleParser> AddExternalSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream);
+        static Windows.Foundation.IAsyncOperation<SubtitleParser> ReadSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream);
 
         ///<summary>Gets the presentation timestamp delay for the given stream. </summary>
         Windows.Foundation.TimeSpan GetStreamDelay();

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -604,12 +604,14 @@ namespace FFmpegInteropX
     runtimeclass SubtitleParser : Windows.Foundation.IClosable
     {
         ///<summary>Returns the parsed subtitle track.</summary>
-        SubtitleStreamInfo SubtitleTrack{get;};
+        SubtitleStreamInfo SubtitleTrack {get;};
 
         [default_overload]
         ///<summary>Adds an external subtitle from a stream.</summary>
         ///<param name="stream">The subtitle stream.</param>
         ///<param name="streamName">The name to use for the subtitle.</param>
+        ///<param name="config">Used to configure subtitles</param>
+        ///<param name="videoDescriptor">Descriptor of the video stream that the subtitle will be attached to. Used to compute sizes of image subs.</param>
         static Windows.Foundation.IAsyncOperation<SubtitleParser> ReadSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream,
             String streamName,
             MediaSourceConfig config,
@@ -623,6 +625,8 @@ namespace FFmpegInteropX
         ///<summary>Adds an external subtitle from an URI.</summary>
         ///<param name="stream">The subtitle URI.</param>
         ///<param name="streamName">The name to use for the subtitle.</param>
+        ///<param name="config">Used to configure subtitles</param>
+        ///<param name="videoDescriptor">Descriptor of the video stream that the subtitle will be attached to. Used to compute sizes of image subs.</param>
         static Windows.Foundation.IAsyncOperation<SubtitleParser> ReadSubtitleAsync(Windows.Foundation.Uri uri,
             String streamName,
             MediaSourceConfig config,

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -599,7 +599,27 @@ namespace FFmpegInteropX
 
         ///<summary>Gets the presentation timestamp delay for the given stream. </summary>
         Windows.Foundation.TimeSpan GetStreamDelay(IStreamInfo stream);
-    };   
+    };
+
+    runtimeclass SubtitleParser : Windows.Foundation.IClosable
+    {
+        SubtitleStreamInfo SubtitleTrack{get;};
+
+        ///<summary>Adds an external subtitle from a stream.</summary>
+        ///<param name="stream">The subtitle stream.</param>
+        ///<param name="streamName">The name to use for the subtitle.</param>
+        static Windows.Foundation.IAsyncOperation<SubtitleParser> AddExternalSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream, String streamName);
+
+        ///<summary>Adds an external subtitle from a stream.</summary>
+        ///<param name="stream">The subtitle stream.</param>
+        static Windows.Foundation.IAsyncOperation<SubtitleParser> AddExternalSubtitleAsync(Windows.Storage.Streams.IRandomAccessStream stream);
+
+        ///<summary>Gets the presentation timestamp delay for the given stream. </summary>
+        Windows.Foundation.TimeSpan GetStreamDelay();
+
+        ///<summary>Sets a presentation timestamp delay for the given stream. Audio, video and subtitle synchronisation can be achieved this way. A positive value will cause samples (or subtitles) to be rendered at a later time. A negative value will make rendering come sooner</summary>
+        void SetStreamDelay(Windows.Foundation.TimeSpan delay);
+     }   
 
     [default_interface]
 #ifdef UWP

--- a/Source/FFmpegInteropX.vcxproj
+++ b/Source/FFmpegInteropX.vcxproj
@@ -246,6 +246,7 @@
     <ClInclude Include="resource.h" />
     <ClInclude Include="StreamBuffer.h" />
     <ClInclude Include="StringUtils.h" />
+    <ClInclude Include="SubtitleParser.h" />
     <ClInclude Include="SubtitleProvider.h" />
     <ClInclude Include="SubtitleProviderBitmap.h" />
     <ClInclude Include="SubtitleProviderSsaAss.h" />
@@ -299,6 +300,7 @@
     </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
     <ClCompile Include="ReferenceCue.cpp" />
+    <ClCompile Include="SubtitleParser.cpp" />
     <ClCompile Include="SubtitleProvider.cpp" />
     <ClCompile Include="SubtitleProviderSsaAss.cpp" />
     <ClCompile Include="SubtitlesConfig.cpp" />

--- a/Source/FFmpegInteropX.vcxproj.filters
+++ b/Source/FFmpegInteropX.vcxproj.filters
@@ -237,6 +237,7 @@
       <Filter>Helpers</Filter>
     </ClInclude>
     <ClInclude Include="resource.h" />
+    <ClInclude Include="SubtitleParser.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CodecChecker.cpp" />
@@ -336,6 +337,7 @@
     <ClCompile Include="text_encoding_detect.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
+    <ClCompile Include="SubtitleParser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="FFmpegInteropX.idl" />

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -1447,7 +1447,7 @@ namespace winrt::FFmpegInteropX::implementation
         }
     }
 
-    IAsyncOperation<winrt::FFmpegInteropX::FFmpegMediaSource> FFmpegMediaSource::AddExternalSubtitleAsyncInternal(IRandomAccessStream stream,
+    IAsyncOperation<winrt::FFmpegInteropX::FFmpegMediaSource> FFmpegMediaSource::ReadExternalSubtitleStreamAsync(IRandomAccessStream stream,
         hstring streamName,
         winrt::FFmpegInteropX::MediaSourceConfig const& config,
         VideoStreamDescriptor videoDescriptor,
@@ -1515,7 +1515,7 @@ namespace winrt::FFmpegInteropX::implementation
         co_await winrt::resume_background();
         auto videoDescriptor = currentVideoStream ? (currentVideoStream->StreamDescriptor()).as<VideoStreamDescriptor>() : nullptr;
 
-        auto externalSubsParser = (co_await AddExternalSubtitleAsyncInternal(stream, streamName, config.as<winrt::FFmpegInteropX::MediaSourceConfig>(), videoDescriptor, dispatcher, windowId, useHdr)).as<winrt::FFmpegInteropX::implementation::FFmpegMediaSource>();
+        auto externalSubsParser = (co_await ReadExternalSubtitleStreamAsync(stream, streamName, config.as<winrt::FFmpegInteropX::MediaSourceConfig>(), videoDescriptor, dispatcher, windowId, useHdr)).as<winrt::FFmpegInteropX::implementation::FFmpegMediaSource>();
 
         Collections::IVectorView<FFmpegInteropX::SubtitleStreamInfo> result;
         {

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -286,7 +286,7 @@ namespace winrt::FFmpegInteropX::implementation
         }
 
         int index = 0;
-        for (auto& stream : subtitleStreams)
+        for (auto& stream : subtitleStreamProviders)
         {
             if (stream->SubtitleTrack == args.Track())
             {
@@ -351,7 +351,7 @@ namespace winrt::FFmpegInteropX::implementation
             }
         }
 
-        for (auto& stream : subtitleStreams)
+        for (auto& stream : subtitleStreamProviders)
         {
             stream->PlaybackItemWeak = playbackItem;
         }
@@ -562,12 +562,12 @@ namespace winrt::FFmpegInteropX::implementation
                     {
                         stream->SubtitleInfo().as<implementation::SubtitleStreamInfo>()->SetDefault();
                         subtitleStrInfos.InsertAt(0, stream->SubtitleInfo());
-                        subtitleStreams.insert(subtitleStreams.begin(), (std::reinterpret_pointer_cast<SubtitleProvider>(stream)));
+                        subtitleStreamProviders.insert(subtitleStreamProviders.begin(), (std::reinterpret_pointer_cast<SubtitleProvider>(stream)));
                     }
                     else
                     {
                         subtitleStrInfos.Append(stream->SubtitleInfo());
-                        subtitleStreams.push_back((std::reinterpret_pointer_cast<SubtitleProvider>(stream)));
+                        subtitleStreamProviders.push_back((std::reinterpret_pointer_cast<SubtitleProvider>(stream)));
                     }
 
                     // enable all subtitle streams for external subtitle parsing
@@ -614,7 +614,7 @@ namespace winrt::FFmpegInteropX::implementation
             auto encodingProperties = videoDescriptor.EncodingProperties();
             auto pixelAspect = (double)encodingProperties.PixelAspectRatio().Numerator() / encodingProperties.PixelAspectRatio().Denominator();
             auto videoAspect = ((double)encodingProperties.Width() / encodingProperties.Height()) / pixelAspect;
-            for (auto& stream : subtitleStreams)
+            for (auto& stream : subtitleStreamProviders)
             {
                 stream->NotifyVideoFrameSize(encodingProperties.Width(), encodingProperties.Height(), videoAspect);
             }
@@ -696,7 +696,7 @@ namespace winrt::FFmpegInteropX::implementation
         {
             mss = MediaStreamSource(currentVideoStream->StreamDescriptor());
         }
-        else if (subtitleStreams.size() == 0 || !config->IsExternalSubtitleParser)
+        else if (subtitleStreamProviders.size() == 0 || !config->IsExternalSubtitleParser)
         {
             //only fail if there are no media streams (audio, video, or subtitle)
             throw_hresult(E_FAIL);
@@ -1088,7 +1088,7 @@ namespace winrt::FFmpegInteropX::implementation
 
         try
         {
-            for (auto& subtitleStream : subtitleStreams)
+            for (auto& subtitleStream : subtitleStreamProviders)
             {
                 subtitleStream->SetStreamDelay(delay);
             }
@@ -1315,7 +1315,7 @@ namespace winrt::FFmpegInteropX::implementation
         auto mss = CreateMediaStreamSource();
 
         MediaSource source = MediaSource::CreateFromMediaStreamSource(mss);
-        for (auto& stream : subtitleStreams)
+        for (auto& stream : subtitleStreamProviders)
         {
             source.ExternalTimedMetadataTracks().Append(stream->SubtitleTrack);
         }
@@ -1447,10 +1447,14 @@ namespace winrt::FFmpegInteropX::implementation
         }
     }
 
-    IAsyncOperation<Collections::IVectorView<FFmpegInteropX::SubtitleStreamInfo>> FFmpegMediaSource::AddExternalSubtitleAsync(IRandomAccessStream stream, hstring streamName)
+    IAsyncOperation<winrt::FFmpegInteropX::FFmpegMediaSource> FFmpegMediaSource::AddExternalSubtitleAsyncInternal(IRandomAccessStream stream,
+        hstring streamName,
+        winrt::FFmpegInteropX::MediaSourceConfig const& config,
+        VideoStreamDescriptor videoDescriptor,
+        DispatcherQueue dispatcher,
+        uint64_t windowId,
+        bool useHdr)
     {
-        auto strong = get_strong();
-
         winrt::apartment_context caller; // Capture calling context.
         co_await winrt::resume_background();
 
@@ -1458,18 +1462,17 @@ namespace winrt::FFmpegInteropX::implementation
         auto subConfig(winrt::make_self<MediaSourceConfig>());
         subConfig->IsExternalSubtitleParser = true;
         subConfig->Subtitles().DefaultStreamName(streamName);
-        subConfig->Subtitles().DefaultSubtitleDelay(config->Subtitles().DefaultSubtitleDelay());
-        subConfig->Subtitles().ExternalSubtitleEncoding(this->config->Subtitles().ExternalSubtitleEncoding());
-        subConfig->Subtitles().ExternalSubtitleAnsiEncoding(this->config->Subtitles().ExternalSubtitleAnsiEncoding());
-        subConfig->Subtitles().OverrideSubtitleStyles(this->config->Subtitles().OverrideSubtitleStyles());
-        subConfig->Subtitles().SubtitleRegion(this->config->Subtitles().SubtitleRegion());
-        subConfig->Subtitles().SubtitleStyle(this->config->Subtitles().SubtitleStyle());
+        subConfig->Subtitles().DefaultSubtitleDelay(config.Subtitles().DefaultSubtitleDelay());
+        subConfig->Subtitles().ExternalSubtitleEncoding(config.Subtitles().ExternalSubtitleEncoding());
+        subConfig->Subtitles().ExternalSubtitleAnsiEncoding(config.Subtitles().ExternalSubtitleAnsiEncoding());
+        subConfig->Subtitles().OverrideSubtitleStyles(config.Subtitles().OverrideSubtitleStyles());
+        subConfig->Subtitles().SubtitleRegion(config.Subtitles().SubtitleRegion());
+        subConfig->Subtitles().SubtitleStyle(config.Subtitles().SubtitleStyle());
         subConfig->Subtitles().AutoSelectForcedSubtitles(false);
-        subConfig->Subtitles().MinimumSubtitleDuration(this->config->Subtitles().MinimumSubtitleDuration());
-        subConfig->Subtitles().AdditionalSubtitleDuration(this->config->Subtitles().AdditionalSubtitleDuration());
-        subConfig->Subtitles().PreventModifiedSubtitleDurationOverlap(this->config->Subtitles().PreventModifiedSubtitleDurationOverlap());
+        subConfig->Subtitles().MinimumSubtitleDuration(config.Subtitles().MinimumSubtitleDuration());
+        subConfig->Subtitles().AdditionalSubtitleDuration(config.Subtitles().AdditionalSubtitleDuration());
+        subConfig->Subtitles().PreventModifiedSubtitleDurationOverlap(config.Subtitles().PreventModifiedSubtitleDurationOverlap());
 
-        auto videoDescriptor = currentVideoStream ? (currentVideoStream->StreamDescriptor()).as<VideoStreamDescriptor>() : nullptr;
         if (videoDescriptor)
         {
             subConfig->AdditionalFFmpegSubtitleOptions = PropertySet();
@@ -1486,7 +1489,7 @@ namespace winrt::FFmpegInteropX::implementation
                 auto encodingProperties = videoDescriptor.EncodingProperties();
                 auto pixelAspect = (double)encodingProperties.PixelAspectRatio().Numerator() / encodingProperties.PixelAspectRatio().Denominator();
                 auto videoAspect = ((double)encodingProperties.Width() / encodingProperties.Height()) / pixelAspect;
-                for (auto& subtitleStream : externalSubsParser->subtitleStreams)
+                for (auto& subtitleStream : externalSubsParser->subtitleStreamProviders)
                 {
                     subtitleStream->NotifyVideoFrameSize(encodingProperties.Width(), encodingProperties.Height(), videoAspect);
                 }
@@ -1499,6 +1502,20 @@ namespace winrt::FFmpegInteropX::implementation
                 if (cancellation()) co_return nullptr;
             }
         }
+
+        co_await caller;
+        co_return externalSubsParser.as<winrt::FFmpegInteropX::FFmpegMediaSource>();
+    }
+
+    IAsyncOperation<Collections::IVectorView<FFmpegInteropX::SubtitleStreamInfo>> FFmpegMediaSource::AddExternalSubtitleAsync(IRandomAccessStream stream, hstring streamName)
+    {
+        auto strong = get_strong();
+
+        winrt::apartment_context caller; // Capture calling context.
+        co_await winrt::resume_background();
+        auto videoDescriptor = currentVideoStream ? (currentVideoStream->StreamDescriptor()).as<VideoStreamDescriptor>() : nullptr;
+
+        auto externalSubsParser = (co_await AddExternalSubtitleAsyncInternal(stream, streamName, config.as<winrt::FFmpegInteropX::MediaSourceConfig>(), videoDescriptor, dispatcher, windowId, useHdr)).as<winrt::FFmpegInteropX::implementation::FFmpegMediaSource>();
 
         Collections::IVectorView<FFmpegInteropX::SubtitleStreamInfo> result;
         {
@@ -1515,7 +1532,7 @@ namespace winrt::FFmpegInteropX::implementation
 
             int subtitleTracksCount = 0;
 
-            for (auto& externalSubtitle : externalSubsParser->subtitleStreams)
+            for (auto& externalSubtitle : externalSubsParser->subtitleStreamProviders)
             {
                 if (externalSubtitle->SubtitleTrack.Cues().Size() > 0)
                 {
@@ -1523,19 +1540,12 @@ namespace winrt::FFmpegInteropX::implementation
                     externalSubtitle->Detach();
 
                     // find and add stream info
-                    for (auto subtitleInfo : externalSubsParser->SubtitleStreams())
-                    {
-                        if (subtitleInfo.SubtitleTrack() == externalSubtitle->SubtitleTrack)
-                        {
-                            subtitleStrInfos.Append(subtitleInfo);
-                            break;
-                        }
-                    }
 
+                    subtitleStrInfos.Append(externalSubtitle->SubtitleInfo());
                     // add stream
                     if (!isClosed)
                     {
-                        subtitleStreams.push_back(externalSubtitle);
+                        subtitleStreamProviders.push_back(externalSubtitle);
                     }
                     if (auto playbackItem = playbackItemWeak.get())
                     {
@@ -1758,7 +1768,7 @@ namespace winrt::FFmpegInteropX::implementation
             m_pReader = nullptr;
         }
 
-        subtitleStreams.clear();
+        subtitleStreamProviders.clear();
         sampleProviders.clear();
         audioStreams.clear();
         videoStreams.clear();
@@ -1883,7 +1893,7 @@ namespace winrt::FFmpegInteropX::implementation
             useHdr = true;
             break;
         case HdrSupport::Automatic:
-            
+
             if (checkDisplayInformation)
             {
                 try
@@ -1916,18 +1926,18 @@ namespace winrt::FFmpegInteropX::implementation
                         {
                             useHdr = true;
                         }
-                    }
-#endif // WinUI
                 }
+#endif // WinUI
+            }
                 catch (...)
                 {
                 }
-            }
+        }
             break;
         default:
             break;
-        }
     }
+}
 
     std::shared_ptr<MediaSampleProvider> FFmpegMediaSource::CreateVideoSampleProvider(AVStream* avStream, AVCodecContext* avVideoCodecCtx, int index)
     {
@@ -1962,7 +1972,7 @@ namespace winrt::FFmpegInteropX::implementation
             CheckUseHardwareAcceleration(avVideoCodecCtx, CodecChecker::HardwareAccelerationHEVC(), hardwareDecoderStatus, config->Video().SystemDecoderHEVCMaxProfile(), config->Video().SystemDecoderHEVCMaxLevel()))
         {
             auto videoProperties = VideoEncodingProperties::CreateHevc();
-
+            videoProperties.Subtype(L"");
             // Check for HEVC bitstream flavor.
             if (avVideoCodecCtx->extradata != nullptr && avVideoCodecCtx->extradata_size > 22 &&
                 (avVideoCodecCtx->extradata[0] || avVideoCodecCtx->extradata[1] || avVideoCodecCtx->extradata[2] > 1))
@@ -2323,7 +2333,7 @@ namespace winrt::FFmpegInteropX::implementation
                 currentAudioStreamInfo = nullptr;
             }
             if (currentVideoStream && args.Request().OldStreamDescriptor() == currentVideoStream->StreamDescriptor())
-            {              
+            {
                 currentVideoStream->DisableStream();
                 currentVideoStream = nullptr;
                 currentAudioStreamInfo = nullptr;
@@ -2343,7 +2353,7 @@ namespace winrt::FFmpegInteropX::implementation
                 {
                     currentVideoStream = stream;
                     currentVideoStream->EnableStream();
-                    
+
                     currentVideoStreamInfo = currentVideoStream->VideoInfo();
                 }
             }
@@ -2418,7 +2428,7 @@ namespace winrt::FFmpegInteropX::implementation
         {
             // Make sure we have at least 4 bytes for BOM check
             bool isEof = false;
-            while (bytesRead < min(bufSize,4) && !isEof)
+            while (bytesRead < min(bufSize, 4) && !isEof)
             {
                 ULONG read = 0;
                 hr = mss->fileStreamData->Read(buf + bytesRead, bufSize - bytesRead, &read);

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -1972,7 +1972,6 @@ namespace winrt::FFmpegInteropX::implementation
             CheckUseHardwareAcceleration(avVideoCodecCtx, CodecChecker::HardwareAccelerationHEVC(), hardwareDecoderStatus, config->Video().SystemDecoderHEVCMaxProfile(), config->Video().SystemDecoderHEVCMaxLevel()))
         {
             auto videoProperties = VideoEncodingProperties::CreateHevc();
-            videoProperties.Subtype(L"");
             // Check for HEVC bitstream flavor.
             if (avVideoCodecCtx->extradata != nullptr && avVideoCodecCtx->extradata_size > 22 &&
                 (avVideoCodecCtx->extradata[0] || avVideoCodecCtx->extradata[1] || avVideoCodecCtx->extradata[2] > 1))

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -246,6 +246,13 @@ namespace winrt::FFmpegInteropX::implementation
         static DispatcherQueue GetCurrentDispatcherQueue();
 
     public://internal:
+        static IAsyncOperation<winrt::FFmpegInteropX::FFmpegMediaSource> AddExternalSubtitleAsyncInternal(IRandomAccessStream stream,
+            hstring streamName,
+            winrt::FFmpegInteropX::MediaSourceConfig const& config,
+            VideoStreamDescriptor videoDescriptor,
+            DispatcherQueue dispatcher,
+            uint64_t windowId,
+            bool useHdr);
         static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromStreamInternalAsync(IRandomAccessStream stream, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId);
         static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromUriInternalAsync(hstring uri, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId);
         static winrt::com_ptr<FFmpegMediaSource> CreateFromStream(IRandomAccessStream const& stream, winrt::com_ptr<MediaSourceConfig> const& config, DispatcherQueue  const& dispatcher, uint64_t windowId, bool useHdr);
@@ -267,6 +274,8 @@ namespace winrt::FFmpegInteropX::implementation
         winrt::com_ptr<MediaSourceConfig> config = { nullptr };
         bool isShuttingDown = false;
 
+        std::vector<std::shared_ptr<SubtitleProvider>> subtitleStreamProviders;
+
     private:
 
         winrt::weak_ref<MediaStreamSource> mssWeak = { nullptr };
@@ -282,7 +291,6 @@ namespace winrt::FFmpegInteropX::implementation
 
         std::vector<std::shared_ptr<MediaSampleProvider>> sampleProviders;
         std::vector<std::shared_ptr<MediaSampleProvider>> audioStreams;
-        std::vector<std::shared_ptr<SubtitleProvider>> subtitleStreams;
         std::vector<std::shared_ptr<MediaSampleProvider>> videoStreams;
 
         std::shared_ptr<MediaSampleProvider> currentVideoStream = { nullptr };

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -246,13 +246,7 @@ namespace winrt::FFmpegInteropX::implementation
         static DispatcherQueue GetCurrentDispatcherQueue();
 
     public://internal:
-        static IAsyncOperation<winrt::FFmpegInteropX::FFmpegMediaSource> AddExternalSubtitleAsyncInternal(IRandomAccessStream stream,
-            hstring streamName,
-            winrt::FFmpegInteropX::MediaSourceConfig const& config,
-            VideoStreamDescriptor videoDescriptor,
-            DispatcherQueue dispatcher,
-            uint64_t windowId,
-            bool useHdr);
+        static IAsyncOperation<winrt::FFmpegInteropX::FFmpegMediaSource> ReadExternalSubtitleStreamAsync(IRandomAccessStream stream, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig const& config, VideoStreamDescriptor videoDescriptor, DispatcherQueue dispatcher, uint64_t windowId, bool useHdr);
         static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromStreamInternalAsync(IRandomAccessStream stream, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId);
         static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromUriInternalAsync(hstring uri, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId);
         static winrt::com_ptr<FFmpegMediaSource> CreateFromStream(IRandomAccessStream const& stream, winrt::com_ptr<MediaSourceConfig> const& config, DispatcherQueue  const& dispatcher, uint64_t windowId, bool useHdr);

--- a/Source/SubtitleParser.cpp
+++ b/Source/SubtitleParser.cpp
@@ -1,25 +1,28 @@
 #include "pch.h"
 #include "SubtitleParser.h"
 #include "SubtitleParser.g.cpp"
+#include "FFmpegMediaSource.h">
 
 namespace winrt::FFmpegInteropX::implementation
 {
-    winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName)
+    winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream,
+        hstring streamName,
+        winrt::FFmpegInteropX::MediaSourceConfig config,
+        winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor,
+        uint64_t windowId,
+        bool useHdr)
     {
         winrt::apartment_context caller; // Capture calling context.
         co_await winrt::resume_background();
-        auto config = winrt::make_self<MediaSourceConfig>();
-        config->IsFrameGrabber = true;
-        config->Video().VideoDecoderMode(VideoDecoderMode::ForceFFmpegSoftwareDecoder);
 
-        auto result = FFmpegMediaSource::CreateFromStream(stream, config, nullptr, 0, false);
+        auto result = (winrt::FFmpegInteropX::implementation::FFmpegMediaSource::AddExternalSubtitleAsyncInternal(stream, streamName, config, nullptr, nullptr, 0, false)).as<winrt::FFmpegInteropX::implementation::FFmpegMediaSource>();
         if (result == nullptr)
         {
-            throw_hresult(E_FAIL);// ref new Exception(E_FAIL, "Could not create MediaStreamSource.");
+            throw_hresult(E_FAIL);// ref new Exception(E_FAIL, "Could not parse stream");
         }
         if (result->SubtitleStreams().Size() != 1)
         {
-            throw_hresult(E_INVALIDARG); //S "No subtitle stream found in stream.");
+            throw_hresult(E_INVALIDARG); //S "Nr of Subtitle stream found in stream in different than 1.");
         }
         co_await caller;
         co_return winrt::make<SubtitleParser>(result);

--- a/Source/SubtitleParser.cpp
+++ b/Source/SubtitleParser.cpp
@@ -14,7 +14,7 @@ namespace winrt::FFmpegInteropX::implementation
         winrt::apartment_context caller; // Capture calling context.
         co_await winrt::resume_background();
 
-        auto parser = co_await winrt::FFmpegInteropX::implementation::FFmpegMediaSource::ReadExternalSubtitleStreamAsync(stream, streamName, config, nullptr, nullptr, 0, false);
+        auto parser = co_await winrt::FFmpegInteropX::implementation::FFmpegMediaSource::ReadExternalSubtitleStreamAsync(stream, streamName, config, videoDescriptor, nullptr, 0, false);
         auto result = parser.as<winrt::FFmpegInteropX::implementation::FFmpegMediaSource>();
         if (result == nullptr)
         {

--- a/Source/SubtitleParser.cpp
+++ b/Source/SubtitleParser.cpp
@@ -6,12 +6,10 @@
 
 namespace winrt::FFmpegInteropX::implementation
 {
-    winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream,
+    IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream,
         hstring streamName,
         winrt::FFmpegInteropX::MediaSourceConfig config,
-        winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor,
-        uint64_t windowId,
-        bool useHdr)
+        winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor)
     {
         winrt::apartment_context caller; // Capture calling context.
         co_await winrt::resume_background();
@@ -30,10 +28,24 @@ namespace winrt::FFmpegInteropX::implementation
         co_return winrt::make<SubtitleParser>(result);
     }
 
-    winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream)
+    IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream)
     {
         auto config = winrt::make<MediaSourceConfig>();
-        return ReadSubtitleAsync(stream, L"", config, nullptr, 0, false);
+        return ReadSubtitleAsync(stream, L"", config, nullptr);
+    }
+
+    IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::ReadSubtitleAsync(Uri uri, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig config, winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor)
+    {
+        auto stream = co_await (RandomAccessStreamReference::CreateFromUri(uri).OpenReadAsync());
+        auto result = co_await ReadSubtitleAsync(stream, streamName, config, videoDescriptor);
+        co_return result;
+    }
+
+    IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::ReadSubtitleAsync(Uri uri)
+    {
+        auto stream = co_await (RandomAccessStreamReference::CreateFromUri(uri).OpenReadAsync());
+        auto result = co_await ReadSubtitleAsync(stream);
+        co_return result;
     }
 
     winrt::FFmpegInteropX::SubtitleStreamInfo SubtitleParser::SubtitleTrack()
@@ -41,12 +53,12 @@ namespace winrt::FFmpegInteropX::implementation
         return interopMSS->SubtitleStreams().GetAt(0);
     }
 
-    winrt::Windows::Foundation::TimeSpan SubtitleParser::GetStreamDelay()
+    TimeSpan SubtitleParser::GetStreamDelay()
     {
         return interopMSS->GetStreamDelay(SubtitleTrack());
     }
 
-    void SubtitleParser::SetStreamDelay(winrt::Windows::Foundation::TimeSpan const& delay)
+    void SubtitleParser::SetStreamDelay(TimeSpan const& delay)
     {
         return interopMSS->SetStreamDelay(SubtitleTrack(), delay);
     }

--- a/Source/SubtitleParser.cpp
+++ b/Source/SubtitleParser.cpp
@@ -1,0 +1,54 @@
+#include "pch.h"
+#include "SubtitleParser.h"
+#include "SubtitleParser.g.cpp"
+
+namespace winrt::FFmpegInteropX::implementation
+{
+    winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName)
+    {
+        winrt::apartment_context caller; // Capture calling context.
+        co_await winrt::resume_background();
+        auto config = winrt::make_self<MediaSourceConfig>();
+        config->IsFrameGrabber = true;
+        config->Video().VideoDecoderMode(VideoDecoderMode::ForceFFmpegSoftwareDecoder);
+
+        auto result = FFmpegMediaSource::CreateFromStream(stream, config, nullptr, 0, false);
+        if (result == nullptr)
+        {
+            throw_hresult(E_FAIL);// ref new Exception(E_FAIL, "Could not create MediaStreamSource.");
+        }
+        if (result->SubtitleStreams().Size() != 1)
+        {
+            throw_hresult(E_INVALIDARG); //S "No subtitle stream found in stream.");
+        }
+        co_await caller;
+        co_return winrt::make<FrameGrabber>(result);
+
+    }
+
+    winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream)
+    {
+        throw hresult_not_implemented();
+    }
+
+    winrt::FFmpegInteropX::SubtitleStreamInfo SubtitleParser::SubtitleTrack()
+    {
+        return interopMSS->SubtitleStreams().GetAt(0);
+    }
+
+    winrt::Windows::Foundation::TimeSpan SubtitleParser::GetStreamDelay()
+    {
+        return interopMSS->GetStreamDelay(SubtitleTrack());
+    }
+
+    void SubtitleParser::SetStreamDelay(winrt::Windows::Foundation::TimeSpan const& delay)
+    {
+        return interopMSS->SetStreamDelay(SubtitleTrack(), delay);
+    }
+
+    void SubtitleParser::Close()
+    {
+        if (interopMSS)
+            interopMSS->Close();
+    }
+}

--- a/Source/SubtitleParser.cpp
+++ b/Source/SubtitleParser.cpp
@@ -22,8 +22,7 @@ namespace winrt::FFmpegInteropX::implementation
             throw_hresult(E_INVALIDARG); //S "No subtitle stream found in stream.");
         }
         co_await caller;
-        co_return winrt::make<FrameGrabber>(result);
-
+        co_return winrt::make<SubtitleParser>(result);
     }
 
     winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> SubtitleParser::AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream)

--- a/Source/SubtitleParser.h
+++ b/Source/SubtitleParser.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "SubtitleParser.g.h"
+
+namespace winrt::FFmpegInteropX::implementation
+{
+    struct SubtitleParser : SubtitleParserT<SubtitleParser>
+    {
+        SubtitleParser() = default;
+
+        static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName);
+        static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream);
+        winrt::FFmpegInteropX::SubtitleStreamInfo SubtitleTrack();
+        winrt::Windows::Foundation::TimeSpan GetStreamDelay();
+        void SetStreamDelay(winrt::Windows::Foundation::TimeSpan const& delay);
+        void Close();
+
+    private:
+        winrt::com_ptr<FFmpegMediaSource> mediaSource = { nullptr };
+        TimedMetadataTrack track = { nullptr };
+        winrt::com_ptr<SubtitleStreamInfo> streamInfo = { nullptr };
+    };
+}
+namespace winrt::FFmpegInteropX::factory_implementation
+{
+    struct SubtitleParser : SubtitleParserT<SubtitleParser, implementation::SubtitleParser>
+    {
+    };
+}

--- a/Source/SubtitleParser.h
+++ b/Source/SubtitleParser.h
@@ -13,7 +13,7 @@ namespace winrt::FFmpegInteropX::implementation
             this->interopMSS = interopMSS;
         }
 
-        static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName);
+        static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig config, winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor, uint64_t windowId, bool useHdr);
         static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream);
         winrt::FFmpegInteropX::SubtitleStreamInfo SubtitleTrack();
         winrt::Windows::Foundation::TimeSpan GetStreamDelay();

--- a/Source/SubtitleParser.h
+++ b/Source/SubtitleParser.h
@@ -1,11 +1,17 @@
 #pragma once
 #include "SubtitleParser.g.h"
+#include <FFmpegMediaSource.h>
 
 namespace winrt::FFmpegInteropX::implementation
 {
     struct SubtitleParser : SubtitleParserT<SubtitleParser>
     {
         SubtitleParser() = default;
+
+        SubtitleParser(winrt::com_ptr<winrt::FFmpegInteropX::implementation::FFmpegMediaSource> interopMSS)
+        {
+            this->interopMSS = interopMSS;
+        }
 
         static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName);
         static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream);
@@ -15,7 +21,7 @@ namespace winrt::FFmpegInteropX::implementation
         void Close();
 
     private:
-        winrt::com_ptr<FFmpegMediaSource> mediaSource = { nullptr };
+        winrt::com_ptr<FFmpegMediaSource> interopMSS = { nullptr };
         TimedMetadataTrack track = { nullptr };
         winrt::com_ptr<SubtitleStreamInfo> streamInfo = { nullptr };
     };

--- a/Source/SubtitleParser.h
+++ b/Source/SubtitleParser.h
@@ -13,8 +13,8 @@ namespace winrt::FFmpegInteropX::implementation
             this->interopMSS = interopMSS;
         }
 
-        static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig config, winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor, uint64_t windowId, bool useHdr);
-        static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> AddExternalSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream);
+        static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig config, winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor, uint64_t windowId, bool useHdr);
+        static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream);
         winrt::FFmpegInteropX::SubtitleStreamInfo SubtitleTrack();
         winrt::Windows::Foundation::TimeSpan GetStreamDelay();
         void SetStreamDelay(winrt::Windows::Foundation::TimeSpan const& delay);

--- a/Source/SubtitleParser.h
+++ b/Source/SubtitleParser.h
@@ -13,13 +13,37 @@ namespace winrt::FFmpegInteropX::implementation
             this->interopMSS = interopMSS;
         }
 
+        ///<summary>Adds an external subtitle from a stream.</summary>
+        ///<param name="stream">The subtitle stream.</param>
+        ///<param name="streamName">The name to use for the subtitle.</param>
+        ///<param name="config">Used to configure subtitles</param>
+        ///<param name="videoDescriptor">Descriptor of the video stream that the subtitle will be attached to. Used to compute sizes of image subs.</param>
         static IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig config, winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor);
+
+        ///<summary>Adds an external subtitle from a stream.</summary>
+        ///<param name="stream">The subtitle stream.</param>
         static IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream);
+
+        ///<summary>Adds an external subtitle from an URI.</summary>
+        ///<param name="uri">The subtitle URI.</param>
+        ///<param name="streamName">The name to use for the subtitle.</param>
+        ///<param name="config">Used to configure subtitles</param>
+        ///<param name="videoDescriptor">Descriptor of the video stream that the subtitle will be attached to. Used to compute sizes of image subs.</param>
         static IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(Uri uri, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig config, winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor);
+
+        ///<summary>Adds an external subtitle from an URI.</summary>
+        ///<param name="stream">The subtitle URI.</param>
         static IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(Uri uri);
+
+        ///<summary>Returns the parsed subtitle track.</summary>
         winrt::FFmpegInteropX::SubtitleStreamInfo SubtitleTrack();
+
+        ///<summary>Gets the presentation timestamp delay for the subtitle stream. </summary>
         TimeSpan GetStreamDelay();
+
+        ///<summary>Sets a presentation timestamp delay for the subtitle stream. Audio, video and subtitle synchronisation can be achieved this way. A positive value will cause samples (or subtitles) to be rendered at a later time. A negative value will make rendering come sooner</summary>
         void SetStreamDelay(TimeSpan const& delay);
+
         void Close();
 
     private:

--- a/Source/SubtitleParser.h
+++ b/Source/SubtitleParser.h
@@ -13,11 +13,13 @@ namespace winrt::FFmpegInteropX::implementation
             this->interopMSS = interopMSS;
         }
 
-        static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig config, winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor, uint64_t windowId, bool useHdr);
-        static winrt::Windows::Foundation::IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream);
+        static IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig config, winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor);
+        static IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(winrt::Windows::Storage::Streams::IRandomAccessStream stream);
+        static IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(Uri uri, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig config, winrt::Windows::Media::Core::VideoStreamDescriptor videoDescriptor);
+        static IAsyncOperation<winrt::FFmpegInteropX::SubtitleParser> ReadSubtitleAsync(Uri uri);
         winrt::FFmpegInteropX::SubtitleStreamInfo SubtitleTrack();
-        winrt::Windows::Foundation::TimeSpan GetStreamDelay();
-        void SetStreamDelay(winrt::Windows::Foundation::TimeSpan const& delay);
+        TimeSpan GetStreamDelay();
+        void SetStreamDelay(TimeSpan const& delay);
         void Close();
 
     private:


### PR DESCRIPTION
This allows creation of TimedMetadataTracks from subtitle files.
It introduces a new class which allows parsing a single subtitle file, and exposes the related functionalities, SubtitleStreamInfo and subtitle delay.

This TimedMetadataTrack can then be used with any MediaPlaybackItem, created by any MediaSource type