### PR TITLE
Set name and language for MediaStreamDescriptor

### DIFF
--- a/Source/MediaSampleProvider.cpp
+++ b/Source/MediaSampleProvider.cpp
@@ -93,7 +93,6 @@ HRESULT MediaSampleProvider::Initialize()
 
 void MediaSampleProvider::InitializeNameLanguageCodec()
 {
-    // unfortunately, setting Name or Language on MediaStreamDescriptor does not have any effect, they are not shown in track selection list
     auto title = av_dict_get(m_pAvStream->metadata, "title", NULL, 0);
     if (title)
     {
@@ -113,6 +112,8 @@ void MediaSampleProvider::InitializeNameLanguageCodec()
                 {
                     auto winLanguage = winrt::Windows::Globalization::Language(entry->TwoLetterCode());
                     Language = winLanguage.DisplayName();
+                    if (m_streamDescriptor)
+                        m_streamDescriptor.Language(winLanguage.LanguageTag());
                 }
                 catch (...)
                 {
@@ -126,6 +127,8 @@ void MediaSampleProvider::InitializeNameLanguageCodec()
             {
                 auto winLanguage = winrt::Windows::Globalization::Language(Language);
                 Language = winLanguage.DisplayName();
+                if (m_streamDescriptor)
+                    m_streamDescriptor.Language(winLanguage.LanguageTag());
             }
             catch (...)
             {
@@ -161,6 +164,9 @@ void MediaSampleProvider::InitializeNameLanguageCodec()
         }
         Name = name;
     }
+
+    if (m_streamDescriptor)
+        m_streamDescriptor.Name(Name);
 
     auto codec = m_pAvCodecCtx->codec_descriptor->name;
     if (codec)


### PR DESCRIPTION
Values for Name and Language propagate to `AudioTrack` and `VideoTrack` as expected. Without these values, getting the Name and Language of each stream is a bit cumbersome.

![image](https://github.com/ffmpeginteropx/FFmpegInteropX/assets/31434093/809ed5aa-905e-41c6-b314-eae38f0f07d7)
