### PR TITLE
Exclude media streams from MediaStreamSource and MediaPlaybackItem

### DIFF
--- a/Samples/MediaPlayerCS/MainPage.xaml.cs
+++ b/Samples/MediaPlayerCS/MainPage.xaml.cs
@@ -59,9 +59,12 @@ namespace MediaPlayerCS
             set;
         }
 
+  
+
         public MainPage()
         {
             Config = new MediaSourceConfig();
+            //Config.General.MediaStreamFilter = new StreamFilter();
 
             this.InitializeComponent();
 

--- a/Samples/MediaPlayerCS/MediaPlayerCS.csproj
+++ b/Samples/MediaPlayerCS/MediaPlayerCS.csproj
@@ -106,6 +106,7 @@
     <Compile Include="MediaPlaybackListPage.xaml.cs">
       <DependentUpon>MediaPlaybackListPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="StreamFilter.cs" />
     <Compile Include="TimeSpanToDoubleConverter.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>

--- a/Samples/MediaPlayerCS/StreamFilter.cs
+++ b/Samples/MediaPlayerCS/StreamFilter.cs
@@ -1,0 +1,18 @@
+using FFmpegInteropX;
+
+namespace MediaPlayerCS
+{
+    /// <summary>
+    /// Example usage for IMediaStreamFilter
+    /// Set it in configuration before calling CreateFrom* methods
+    /// Config.General.MediaStreamFilter = new StreamFilter();
+    ///  
+    /// </summary>
+    class StreamFilter : IMediaStreamFilter
+    {
+        public bool ShouldAddStream(IStreamInfo streamInfo)
+        {
+            return streamInfo.StreamIndex != 1;
+        }
+    }
+}

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -838,5 +838,15 @@ namespace FFmpegInteropX
         ///<summary>Keep metadata available after MediaSource was closed.</summary>
         ///<remarks>Set this to false to cleanup more memory automatically, if you are sure you don't need metadata after playback end.</remarks>
         Boolean KeepMetadataOnMediaSourceClosed{ get; set; };
+
+        ///<summary>Allows applications to apply custom logic to exclude streams from the MediaStreamSource or MediaPlaybackItem.</summary>
+        IMediaStreamFilter MediaStreamFilter{get; set;};
     };
+
+    ///<summary>Allows applications to apply custom logic to exclude streams from the MediaStreamSource or MediaPlaybackItem.</summary>
+    interface IMediaStreamFilter
+    {
+        ///<summary>Return true if the media stream descrived by streamInfo should be added to the media stream source</summary>
+        Boolean ShouldAddStream(IStreamInfo streamInfo);
+    }
 }

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -514,7 +514,7 @@ namespace winrt::FFmpegInteropX::implementation
             if (avStream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO && !config->IsFrameGrabber && !config->IsExternalSubtitleParser)
             {
                 stream = CreateAudioStream(avStream, index);
-                if (stream)
+                if (stream && ShouldAddStream(stream->StreamInfo()))
                 {
                     if (index == audioStreamIndex)
                     {
@@ -537,7 +537,7 @@ namespace winrt::FFmpegInteropX::implementation
             else if (avStream->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && !config->IsExternalSubtitleParser)
             {
                 stream = CreateVideoStream(avStream, index);
-                if (stream)
+                if (stream && ShouldAddStream(stream->StreamInfo()))
                 {
                     if (index == videoStreamIndex)
                     {
@@ -556,7 +556,7 @@ namespace winrt::FFmpegInteropX::implementation
             else if (avStream->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE)
             {
                 stream = CreateSubtitleSampleProvider(avStream, index);
-                if (stream)
+                if (stream && ShouldAddStream(stream->StreamInfo()))
                 {
                     if (index == subtitleStreamIndex)
                     {

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -336,6 +336,16 @@ namespace winrt::FFmpegInteropX::implementation
         TimeSpan lastSeek{ 0 };
 
         void OnPositionChanged(MediaPlaybackSession const& sender, IInspectable const& args);
+
+        bool ShouldAddStream(IStreamInfo const& stream)
+        {
+            auto mediaStreamFilter = config->General().MediaStreamFilter();
+            if (mediaStreamFilter)
+            {
+                return mediaStreamFilter.ShouldAddStream(stream);
+            }
+            else return true; //no filter means all streams go in
+        }
     };
 }
 namespace winrt::FFmpegInteropX::factory_implementation

--- a/Source/GeneralConfig.h
+++ b/Source/GeneralConfig.h
@@ -55,5 +55,8 @@ namespace winrt::FFmpegInteropX::implementation
         ///<summary>Keep metadata available after MediaSource was closed.</summary>
         ///<remarks>Set this to false to cleanup more memory automatically, if you are sure you don't need metadata after playback end.</remarks>
         PROPERTY(KeepMetadataOnMediaSourceClosed, bool, true);
+
+        ///<summary>Allows applications to apply custom logic to exclude streams from the MediaStreamSource or MediaPlaybackItem.</summary>
+        PROPERTY_CONST(MediaStreamFilter, winrt::FFmpegInteropX::IMediaStreamFilter, nullptr);
     };
 }


### PR DESCRIPTION
This adds a new interface that can be used by applications to decide if a stream should be included in the MediaStreamSource or MediaPlaybackItem.

Users need to implement the interface and pass it in the MediaSourceConfig.General options. 

This should enable the scenario described on #425 

Open points:
1. I don't really like the use of the word "filter" there, not to be confused with effects or media filters. Haven't found a better wording yet.
2. Should we support async calls as well?

