### PR TITLE
Multiple input files

### DIFF
--- a/Samples/MediaPlayerCS/MainPage.xaml
+++ b/Samples/MediaPlayerCS/MainPage.xaml
@@ -53,6 +53,12 @@
                         <Button Content="Media playback list sample" Click="GoToMediaPlaybackListSample"></Button>
                         <Button Content="Start playback" Click="CreatePlaybackItemAndStartPlayback"  Margin="0,20,10,10" />
 
+                        <TextBlock Text="Add Local File or URI"/>
+                        <StackPanel Orientation="Horizontal">
+                            <AppBarButton Content="Open Local File" Icon="OpenFile" Margin="0, 10, 10, 0" Click="AddLocalFile"/>
+                            <TextBox x:Name="tbUri2" PlaceholderText="Enter URI and press Enter" InputScope="Url" Width="210" Height="30" KeyUp="URIBoxKeyUp"/>
+                        </StackPanel>
+
                         <ToggleSwitch Header="Allow Hardware Accelection" OffContent="OFF" OnContent="ON" x:Name="AutoDetect" Toggled="AutoDetect_Toggled" />
                         <ToggleSwitch Header="Force System Video Decoder" OffContent="OFF" OnContent="ON" x:Name="PassthroughVideo" Toggled="PassthroughVideo_Toggled" Margin="0,0,0,20" />
 

--- a/Samples/MediaPlayerCS/MainPage.xaml.cs
+++ b/Samples/MediaPlayerCS/MainPage.xaml.cs
@@ -721,5 +721,35 @@ namespace MediaPlayerCS
                 await DisplayErrorMessage(ex.ToString());
             }
         }
+
+        private async void AddLocalFile(object sender, RoutedEventArgs e)
+        {
+            if(FFmpegMSS==null)
+            {
+                await DisplayErrorMessage($"Open a file first");
+            }
+            FileOpenPicker filePicker = new FileOpenPicker();
+            filePicker.SettingsIdentifier = "VideoFile";
+            filePicker.ViewMode = PickerViewMode.Thumbnail;
+            filePicker.SuggestedStartLocation = PickerLocationId.VideosLibrary;
+            filePicker.FileTypeFilter.Add("*");
+
+            // Show file picker so user can select a file
+            StorageFile file = await filePicker.PickSingleFileAsync();
+
+            if (file != null)
+            {
+                IRandomAccessStream readStream = await file.OpenAsync(FileAccessMode.Read);
+
+                try
+                {
+                    await FFmpegMSS.AddStreamsAsync(readStream);
+                }
+                catch (Exception ex)
+                {
+                    await DisplayErrorMessage(ex.Message);
+                }
+            }
+        }
     }
 }

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -599,6 +599,18 @@ namespace FFmpegInteropX
 
         ///<summary>Gets the presentation timestamp delay for the given stream. </summary>
         Windows.Foundation.TimeSpan GetStreamDelay(IStreamInfo stream);
+
+        /// <summary>
+        /// Adds the media streams from the given input stream to the media source.
+        /// </summary>
+        [default_overload]
+        Windows.Foundation.IAsyncAction AddStreamsAsync(Windows.Storage.Streams.IRandomAccessStream stream);
+
+        /// <summary>
+        /// Adds the media streams from the given input URI to the media source.
+        /// </summary>
+        Windows.Foundation.IAsyncAction AddStreamsAsync(String uri);
+
     };
 
     runtimeclass SubtitleParser : Windows.Foundation.IClosable

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -1783,8 +1783,6 @@ namespace winrt::FFmpegInteropX::implementation
 
             auto lastStreamContext = ioStreamCollection.at(ioStreamCollection.size() - 1);
 
-            InitFFmpegContext(lastStreamContext);
-
             if (mssWeak)
             {
                 for (auto audioStream : lastStreamContext->audioStreams)

--- a/Source/MediaSampleProvider.h
+++ b/Source/MediaSampleProvider.h
@@ -188,6 +188,11 @@ public:
         streamDelay = newDelay;
     }
 
+    shared_ptr<FFmpegReader> GetReader()
+    {
+        return m_pReader;
+    }
+
 protected:
     MediaSampleProvider(
         std::shared_ptr<FFmpegReader> reader,


### PR DESCRIPTION
Hello @lukasf 

I've been playing around with a new feature:  add multiple input files to the FFmpegMediaSource. This PR showcases a working prototype.

Some notes and open questions:

1. It is not possible to add the extra streams during playback (unfortunately). I realize that it should be impossible to add external subs this way, if we are to ever implement subs through winRT APIs we need to keep this in mind.
2. How do we handle files that have different media durations? at this point I do not update the overall length of the MediaStreamSource when a longer file is added, so the automatic increment kicks in.
3. It appears that syncing the multiple ffmpegreaders in the onStarting event is enough to keep them in sync (the event happens when stream switching and when playback starts / resumes)
4. Metadata tags will have to be merged / handled somehow
5. We need an additional property in StreamInfos so that consumers know which IO context they belong to (I am thinking some sort of user provided key and we can also group metadata by that key)
6. Fast seeking will not work on ffmpeg readers that do not have an active video stream. This will eventually be fixed, not a big deal atm.
7. Probably weird bugs hidden in the bushes.
8. This PR is based on the ffmpeg 6 / 7 branch
9. Feedback is welcome :)