### PR TITLE
Fix audioeffects with new ffmpeg channel layout APIs

### DIFF
--- a/Source/AudioFilter.h
+++ b/Source/AudioFilter.h
@@ -131,7 +131,7 @@ class AudioFilter : public IAvFilter
         hr = av_opt_set_q(avSource_ctx, "time_base", inputCodecCtx->time_base, AV_OPT_SEARCH_CHILDREN);
         hr = av_opt_set_int(avSource_ctx, "sample_rate", frame->sample_rate, AV_OPT_SEARCH_CHILDREN);
         hr = av_opt_set(avSource_ctx, "sample_fmt", av_get_sample_fmt_name((AVSampleFormat)frame->format), AV_OPT_SEARCH_CHILDREN);
-        hr = av_opt_set(avSource_ctx, "ch_layout", channel_layout_name, AV_OPT_SEARCH_CHILDREN);
+        hr = av_opt_set(avSource_ctx, "channel_layout", channel_layout_name, AV_OPT_SEARCH_CHILDREN);
 
         /* Now initialize the filter; we pass NULL options, since we have already
         * set all the options above. */


### PR DESCRIPTION
This fixes audio effects on latest winui branch. When switching to new channel layouts, they renamed all the fields from channel_layout to ch_layout, except for this one.

Thanks @sakib1361 for reporting!