### PR TITLE
editorconfig: Remove unnecessary rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,9 +7,6 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 4
-end_of_line = crlf
-trim_trailing_whitespace = true
-insert_final_newline = true
 csharp_using_directive_placement = outside_namespace:silent
 csharp_prefer_simple_using_statement = true:suggestion
 csharp_prefer_braces = true:silent
@@ -20,24 +17,13 @@ csharp_style_expression_bodied_constructors = false:silent
 csharp_style_expression_bodied_operators = false:silent
 csharp_indent_labels = one_less_than_current
 
-[*.sln]
-indent_style = tab
-
 # Xml project files
 [*.{config,csproj,njsproj,targets,vcxitems,vcxproj,vcxproj.filters}]
 indent_size = 2
-end_of_line = crlf
-insert_final_newline = false
 
 # XML config files
 [*.{msbuild,props,targets,ruleset,config,nuspec}]
 indent_size = 2
-end_of_line = crlf
-insert_final_newline = false
-
-# Windows Shell scripts
-[*.{cmd,bat,ps1}]
-end_of_line = crlf
 
 [*.{cs,vb}]
 #### Naming styles ####


### PR DESCRIPTION
None of these rules are needed for Visual Studio and these also do not stem from any defaults/templates of VS.

Resubmission of #433 