### PR TITLE
fix stereo downmix on 32 bit PCM

### DIFF
--- a/Source/UncompressedAudioSampleProvider.cpp
+++ b/Source/UncompressedAudioSampleProvider.cpp
@@ -145,11 +145,12 @@ void UncompressedAudioSampleProvider::SetMediaEncodingProperties(AVSampleFormat 
 
     // set encoding properties
     encodingProperties.Subtype(outSampleFormat == AV_SAMPLE_FMT_FLT ? MediaEncodingSubtypes::Float() : MediaEncodingSubtypes::Pcm());
+    encodingProperties.Properties().Insert(MF_MT_AUDIO_CHANNEL_MASK, winrt::box_value(reportedChannelLayout));
+
     encodingProperties.BitsPerSample(bitsPerSample);
     encodingProperties.SampleRate(outSampleRate);
     encodingProperties.ChannelCount(outChannelLayout.nb_channels);
     encodingProperties.Bitrate(bitsPerSample * outSampleRate * outChannelLayout.nb_channels);
-    encodingProperties.Properties().Insert(MF_MT_AUDIO_CHANNEL_MASK, winrt::box_value(reportedChannelLayout));
 }
 
 HRESULT UncompressedAudioSampleProvider::CheckFormatChanged(AVSampleFormat format, const AVChannelLayout& channelLayout, int sampleRate)


### PR DESCRIPTION
The version on master will throw this error

> Exception thrown at 0x00007FF86559831A (KernelBase.dll) in MediaPlayerCS.exe: WinRT originate error - 0xC00D5212 : 'Decoder error'.

There will be no sound because the media stream source will not request samples from the audio stream.

This code on this branch will work. For some reason, the order in which those properties are set matters.
This fully fixes #440 , together with some other fixes that were part of the winUI config feature.
