### PR TITLE
Expose IsActive and IsHdr for Audio and Video stream infos

### DIFF
--- a/Source/AudioStreamInfo.h
+++ b/Source/AudioStreamInfo.h
@@ -20,11 +20,22 @@ namespace winrt::FFmpegInteropX::implementation
         int64_t Bitrate();
         bool IsDefault();
         int32_t StreamIndex();
+        bool IsActive()
+        {
+            return active;
+        }
+
     public:
         bool SetDefault()
         {
             isDefault = true;
             return isDefault;
+        }
+
+        bool SetIsActive(bool value)
+        {
+            active = value;
+            return active;
         }
 
     private:
@@ -42,6 +53,7 @@ namespace winrt::FFmpegInteropX::implementation
 
         FFmpegInteropX::DecoderEngine decoderEngine;
         int streamIndex = -1;
+        bool active = false;
     };
 }
 namespace winrt::FFmpegInteropX::factory_implementation

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -183,7 +183,10 @@ namespace FFmpegInteropX
         Boolean IsActive{ get; };
 
         ///<summary>The video has HDR metadata. This value is always false if DecoderEngine is SystemDecoder.</summary>
-        Boolean IsHdr{ get; };
+        Boolean HasHdrMetadata{ get; };
+
+        ///<summary>HDR is enabled for this stream. This value is always false if DecoderEngine is SystemDecoder.</summary>
+        Boolean IsHdrActive{ get; };
     };
 
 #ifdef UWP

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -139,6 +139,8 @@ namespace FFmpegInteropX
         Int32 BitsPerSample{ get; };
 
         DecoderEngine DecoderEngine{ get; };
+
+        Boolean IsActive{ get; };
     };
 
 #ifdef UWP
@@ -178,6 +180,10 @@ namespace FFmpegInteropX
 
         HardwareDecoderStatus HardwareDecoderStatus{ get; };
         DecoderEngine DecoderEngine{ get; };
+        Boolean IsActive{ get; };
+
+        ///<summary>The video has HDR metadata. This value is always false if DecoderEngine is SystemDecoder.</summary>
+        Boolean IsHdr{ get; };
     };
 
 #ifdef UWP

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -1943,8 +1943,8 @@ namespace winrt::FFmpegInteropX::implementation
             break;
         default:
             break;
+        }
     }
-}
 
     std::shared_ptr<MediaSampleProvider> FFmpegMediaSource::CreateVideoSampleProvider(AVStream* avStream, AVCodecContext* avVideoCodecCtx, int index)
     {

--- a/Source/MediaSampleProvider.h
+++ b/Source/MediaSampleProvider.h
@@ -225,7 +225,8 @@ protected:
     DecoderEngine decoder = DecoderEngine::FFmpegSoftwareDecoder;
     winrt::com_ptr<ID3D11Device> device = NULL;
     winrt::com_ptr<ID3D11DeviceContext> deviceContext = NULL;
-
+    AudioStreamInfo audioStreamInfo = NULL;
+    VideoStreamInfo videoStreamInfo = NULL;
 };
 
 // free AVBufferRef*

--- a/Source/UncompressedVideoSampleProvider.cpp
+++ b/Source/UncompressedVideoSampleProvider.cpp
@@ -132,7 +132,6 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
 
     if (codecPar->color_primaries != AVCOL_PRI_UNSPECIFIED && (codecPar->color_primaries < MFVideoPrimaries_BT2020 || applyHdrColorInfo))
     {
-        hasHdrMetadata = true;
         MFVideoPrimaries videoPrimaries{ MFVideoPrimaries_Unknown };
         switch (codecPar->color_primaries)
         {
@@ -178,8 +177,6 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
 
     if (codecPar->color_trc != AVCOL_TRC_UNSPECIFIED && (codecPar->color_trc < MFVideoTransFunc_2020_const || applyHdrColorInfo))
     {
-        hasHdrMetadata = true;
-
         MFVideoTransferFunction videoTransferFunc{ MFVideoTransFunc_Unknown };
         switch (codecPar->color_trc)
         {
@@ -242,8 +239,6 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
     const AVContentLightMetadata* contentLightMetadata{ reinterpret_cast<const AVContentLightMetadata*>(av_packet_side_data_get(m_pAvStream->codecpar->coded_side_data, m_pAvStream->codecpar->nb_coded_side_data, AV_PKT_DATA_CONTENT_LIGHT_LEVEL)) };
     if (contentLightMetadata != nullptr && applyHdrColorInfo)
     {
-        hasHdrMetadata = true;
-
         properties.Insert(MF_MT_MAX_LUMINANCE_LEVEL, PropertyValue::CreateUInt32(contentLightMetadata->MaxCLL));
         properties.Insert(MF_MT_MAX_FRAME_AVERAGE_LUMINANCE_LEVEL, PropertyValue::CreateUInt32(contentLightMetadata->MaxFALL));
     }
@@ -251,7 +246,6 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
     const AVMasteringDisplayMetadata* masteringDisplayMetadata{ reinterpret_cast<const AVMasteringDisplayMetadata*>(av_packet_side_data_get(m_pAvStream->codecpar->coded_side_data, m_pAvStream->codecpar->nb_coded_side_data, AV_PKT_DATA_MASTERING_DISPLAY_METADATA)) };
     if (masteringDisplayMetadata != nullptr && applyHdrColorInfo)
     {
-        hasHdrMetadata = true;
         if (masteringDisplayMetadata->has_luminance)
         {
             constexpr UINT32 MASTERING_DISP_LUMINANCE_SCALE{ 10000 };
@@ -276,6 +270,9 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
             properties.Insert(MF_MT_CUSTOM_VIDEO_PRIMARIES, PropertyValue::CreateUInt8Array(data));
         }
     }
+
+    hasHdrMetadata = (masteringDisplayMetadata != nullptr && (masteringDisplayMetadata->has_primaries || masteringDisplayMetadata->has_luminance)) || contentLightMetadata != nullptr;
+    isHdrActive = hasHdrMetadata && applyHdrColorInfo;
 
     videoProperties.Properties().Insert(MF_MT_INTERLACE_MODE, winrt::box_value((UINT32)_MFVideoInterlaceMode::MFVideoInterlace_MixedInterlaceOrProgressive));
 
@@ -753,7 +750,7 @@ void UncompressedVideoSampleProvider::CheckFrameSize(AVFrame* avFrame)
             outputHeight = avFrame->height;
             outputFrameWidth = frameWidth;
             outputFrameHeight = frameHeight;
-            
+
             encProp.Width(outputFrameWidth);
             encProp.Height(outputFrameHeight);
 

--- a/Source/UncompressedVideoSampleProvider.cpp
+++ b/Source/UncompressedVideoSampleProvider.cpp
@@ -271,7 +271,7 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
         }
     }
 
-    hasHdrMetadata = (masteringDisplayMetadata != nullptr && (masteringDisplayMetadata->has_primaries || masteringDisplayMetadata->has_luminance)) || contentLightMetadata != nullptr;
+    hasHdrMetadata = (masteringDisplayMetadata != nullptr && (masteringDisplayMetadata->has_primaries || masteringDisplayMetadata->has_luminance)) || contentLightMetadata != nullptr || codecPar->color_primaries >= MFVideoPrimaries_BT2020 || codecPar->color_trc >= MFVideoTransFunc_2020_const;
     isHdrActive = hasHdrMetadata && applyHdrColorInfo;
 
     videoProperties.Properties().Insert(MF_MT_INTERLACE_MODE, winrt::box_value((UINT32)_MFVideoInterlaceMode::MFVideoInterlace_MixedInterlaceOrProgressive));

--- a/Source/UncompressedVideoSampleProvider.cpp
+++ b/Source/UncompressedVideoSampleProvider.cpp
@@ -132,6 +132,7 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
 
     if (codecPar->color_primaries != AVCOL_PRI_UNSPECIFIED && (codecPar->color_primaries < MFVideoPrimaries_BT2020 || applyHdrColorInfo))
     {
+        hasHdrMetadata = true;
         MFVideoPrimaries videoPrimaries{ MFVideoPrimaries_Unknown };
         switch (codecPar->color_primaries)
         {
@@ -177,6 +178,8 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
 
     if (codecPar->color_trc != AVCOL_TRC_UNSPECIFIED && (codecPar->color_trc < MFVideoTransFunc_2020_const || applyHdrColorInfo))
     {
+        hasHdrMetadata = true;
+
         MFVideoTransferFunction videoTransferFunc{ MFVideoTransFunc_Unknown };
         switch (codecPar->color_trc)
         {
@@ -239,6 +242,8 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
     const AVContentLightMetadata* contentLightMetadata{ reinterpret_cast<const AVContentLightMetadata*>(av_packet_side_data_get(m_pAvStream->codecpar->coded_side_data, m_pAvStream->codecpar->nb_coded_side_data, AV_PKT_DATA_CONTENT_LIGHT_LEVEL)) };
     if (contentLightMetadata != nullptr && applyHdrColorInfo)
     {
+        hasHdrMetadata = true;
+
         properties.Insert(MF_MT_MAX_LUMINANCE_LEVEL, PropertyValue::CreateUInt32(contentLightMetadata->MaxCLL));
         properties.Insert(MF_MT_MAX_FRAME_AVERAGE_LUMINANCE_LEVEL, PropertyValue::CreateUInt32(contentLightMetadata->MaxFALL));
     }
@@ -246,6 +251,7 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
     const AVMasteringDisplayMetadata* masteringDisplayMetadata{ reinterpret_cast<const AVMasteringDisplayMetadata*>(av_packet_side_data_get(m_pAvStream->codecpar->coded_side_data, m_pAvStream->codecpar->nb_coded_side_data, AV_PKT_DATA_MASTERING_DISPLAY_METADATA)) };
     if (masteringDisplayMetadata != nullptr && applyHdrColorInfo)
     {
+        hasHdrMetadata = true;
         if (masteringDisplayMetadata->has_luminance)
         {
             constexpr UINT32 MASTERING_DISP_LUMINANCE_SCALE{ 10000 };

--- a/Source/UncompressedVideoSampleProvider.h
+++ b/Source/UncompressedVideoSampleProvider.h
@@ -82,6 +82,12 @@ public:
         UncompressedSampleProvider::NotifyCreateSource();
     }
 
+    virtual void InitializeStreamInfo() override
+    {
+        MediaSampleProvider::InitializeStreamInfo();
+        videoStreamInfo.as<implementation::VideoStreamInfo>()->SetIsHdr(true);
+    }
+
 private:
     void SelectOutputFormat();
     HRESULT InitializeScalerIfRequired(AVFrame* avFrame);
@@ -112,5 +118,6 @@ private:
     winrt::Windows::Foundation::IInspectable minLuminance = { nullptr };
     winrt::Windows::Foundation::IInspectable maxLuminance = { nullptr };
     winrt::Windows::Foundation::IInspectable customPrimaries = { nullptr };
+    bool hasHdrMetadata = false;
 };
 

--- a/Source/UncompressedVideoSampleProvider.h
+++ b/Source/UncompressedVideoSampleProvider.h
@@ -85,7 +85,11 @@ public:
     virtual void InitializeStreamInfo() override
     {
         MediaSampleProvider::InitializeStreamInfo();
-        videoStreamInfo.as<implementation::VideoStreamInfo>()->SetIsHdr(true);
+
+        auto videoStreamInfoImpl = videoStreamInfo.as<implementation::VideoStreamInfo>();
+
+        videoStreamInfoImpl->SetHasHdrMetadata(hasHdrMetadata);
+        videoStreamInfoImpl->SetIsHdrActive(isHdrActive);
     }
 
 private:
@@ -119,5 +123,6 @@ private:
     winrt::Windows::Foundation::IInspectable maxLuminance = { nullptr };
     winrt::Windows::Foundation::IInspectable customPrimaries = { nullptr };
     bool hasHdrMetadata = false;
+    bool isHdrActive = false;
 };
 

--- a/Source/VideoStreamInfo.h
+++ b/Source/VideoStreamInfo.h
@@ -29,7 +29,34 @@ namespace winrt::FFmpegInteropX::implementation
         bool IsDefault();
         int32_t StreamIndex();
 
+        bool IsActive()
+        {
+            return active;
+        }
+
+        bool IsHdr()
+        {
+            return isHdr;
+        }
+
     public:
+        bool SetDefault()
+        {
+            isDefault = true;
+            return isDefault;
+        }
+
+        void SetIsActive(bool value)
+        {
+            active = value;
+        }
+
+        bool SetIsHdr(bool value)
+        {
+            isHdr = value;
+            return isHdr;
+        }
+
         hstring name{};
         hstring language{};
         hstring codecName{};
@@ -46,10 +73,9 @@ namespace winrt::FFmpegInteropX::implementation
         FFmpegInteropX::HardwareDecoderStatus hardwareDecoderStatus;
         FFmpegInteropX::DecoderEngine decoderEngine;
         int streamIndex = -1;
-        void SetDefault()
-        {
-            isDefault = true;
-        }
+    private:
+        bool active = false;
+        bool isHdr = false;
     };
 }
 namespace winrt::FFmpegInteropX::factory_implementation

--- a/Source/VideoStreamInfo.h
+++ b/Source/VideoStreamInfo.h
@@ -34,9 +34,14 @@ namespace winrt::FFmpegInteropX::implementation
             return active;
         }
 
-        bool IsHdr()
+        bool HasHdrMetadata()
         {
-            return isHdr;
+            return hasHdrMetadata;
+        }
+
+        bool IsHdrActive()
+        {
+            return isHdrActive;
         }
 
     public:
@@ -51,10 +56,16 @@ namespace winrt::FFmpegInteropX::implementation
             active = value;
         }
 
-        bool SetIsHdr(bool value)
+        bool SetHasHdrMetadata(bool value)
         {
-            isHdr = value;
-            return isHdr;
+            hasHdrMetadata = value;
+            return hasHdrMetadata;
+        }
+
+        bool SetIsHdrActive(bool value)
+        {
+            isHdrActive = value;
+            return isHdrActive;
         }
 
         hstring name{};
@@ -75,7 +86,8 @@ namespace winrt::FFmpegInteropX::implementation
         int streamIndex = -1;
     private:
         bool active = false;
-        bool isHdr = false;
+        bool hasHdrMetadata = false;
+        bool isHdrActive = false;
     };
 }
 namespace winrt::FFmpegInteropX::factory_implementation


### PR DESCRIPTION
This PR adds the following properties:
IsActive to VideoStreamInfo and AudioStreamInfo. This is a convenience method for determining which StreamInfo is the active stream info without querying the FFmpegMediaSource.

IsHdr for VideoStreamInfo to determine if a stream has HDR metadata when we use uncompressed providers (Directx or ffmpeg software decoder)
