### PR TITLE
Fix subtitles when no size received

### DIFF
--- a/Source/SubtitleProviderBitmap.h
+++ b/Source/SubtitleProviderBitmap.h
@@ -299,6 +299,13 @@ private:
             subtitleWidth = m_pAvCodecCtx->width;
             subtitleHeight = m_pAvCodecCtx->height;
 
+            if (subtitleWidth == 0 && subtitleHeight == 0)
+            {
+                OutputDebugString(L"Warning: No subtitle size received. Assuming equal to video size.");
+                subtitleWidth = videoWidth;
+                subtitleHeight = videoHeight;
+            }
+
             if (subtitleWidth > 0 && subtitleHeight > 0)
             {
                 if (subtitleWidth != videoWidth || subtitleHeight != videoHeight || (videoAspectRatio > 0 && videoAspectRatio != 1))

--- a/Source/SubtitleProviderBitmap.h
+++ b/Source/SubtitleProviderBitmap.h
@@ -301,7 +301,7 @@ private:
 
             if (subtitleWidth == 0 && subtitleHeight == 0)
             {
-                OutputDebugString(L"Warning: No subtitle size received. Assuming equal to video size.");
+                OutputDebugString(L"Warning: No subtitle size received. Assuming equal to video size.\n");
                 subtitleWidth = videoWidth;
                 subtitleHeight = videoHeight;
             }


### PR DESCRIPTION
This fixes subtitles in the video reported by @ramtinak. If we do not get any size info for bitmap subs, we optimistically assume the size is same as the video size. Can't do any better than that.