### PR TITLE
update cswinrt, set aot support, UWP dotnet 9, various nuget fixes

### DIFF
--- a/Build-OverallPackage.ps1
+++ b/Build-OverallPackage.ps1
@@ -21,6 +21,7 @@ param(
 
 
 nuget pack .\Build\FFmpegInteropX.nuspec `
-    -Properties "id=FFmpegInteropX;repositoryUrl=$FFmpegUrl;repositoryCommit=$FFmpegCommit;winsdk=$WindowsTargetPlatformVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
+    -Properties "id=FFmpegInteropX;repositoryUrl=$FFmpegInteropXUrl;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
     -Version $NugetPackageVersion `
-    -OutputDirectory "${PSScriptRoot}\Output\NuGet"
+    -OutputDirectory "${PSScriptRoot}\Output\NuGet" `
+	

--- a/Build/FFmpegInteropX.Desktop.Lib.nuspec
+++ b/Build/FFmpegInteropX.Desktop.Lib.nuspec
@@ -18,18 +18,24 @@
     <repository type="git" url="$repositoryUrl$" branch="$repositoryBranch$" commit="$repositoryCommit$" />
   </metadata>
   <files>
-    
+  
     <file src="..\Output\FFmpegInteropX.DotNet\Release\FFmpegInteropX.DotNet.dll"   target="lib\net6.0-windows$winsdk$" />
     <file src="..\Output\FFmpegInteropX.DotNet\Release\FFmpegInteropX.xml"          target="lib\net6.0-windows$winsdk$" />
     
     <file src="..\Output\FFmpegInteropX\x86\Release_Desktop\FFmpegInteropX.dll"     target="runtimes\win-x86\native" />
     <file src="..\Output\FFmpegInteropX\x86\Release_Desktop\FFmpegInteropX.pdb"     target="runtimes\win-x86\native" />
+	<file src="..\Output\FFmpegInteropX\x86\Release_Desktop\FFmpegInteropX.winmd"   target="runtimes\win-x86\native" />
+    <file src="..\Output\FFmpegInteropX\x86\Release_Desktop\FFmpegInteropX.xml"     target="runtimes\win-x86\native" />
 
     <file src="..\Output\FFmpegInteropX\x64\Release_Desktop\FFmpegInteropX.dll"     target="runtimes\win-x64\native" />
-    <file src="..\Output\FFmpegInteropX\x64\Release_Desktop\FFmpegInteropX.pdb"     target="runtimes\win-x64\native" />
+    <file src="..\Output\FFmpegInteropX\x64\Release_Desktop\FFmpegInteropX.pdb"     target="runtimes\win-x64\native" />   
+	<file src="..\Output\FFmpegInteropX\x64\Release_Desktop\FFmpegInteropX.winmd"   target="runtimes\win-x64\native" />
+    <file src="..\Output\FFmpegInteropX\x64\Release_Desktop\FFmpegInteropX.xml"     target="runtimes\win-x64\native" />
 
-    <file src="..\Output\FFmpegInteropX\ARM64\Release_Desktop\FFmpegInteropX.dll"   target="runtimes\win-arm64\native" />
-    <file src="..\Output\FFmpegInteropX\ARM64\Release_Desktop\FFmpegInteropX.pdb"   target="runtimes\win-arm64\native" />
+    <file src="..\Output\FFmpegInteropX\ARM64\Release_Desktop\FFmpegInteropX.dll"     target="runtimes\win-arm64\native" />
+    <file src="..\Output\FFmpegInteropX\ARM64\Release_Desktop\FFmpegInteropX.pdb"     target="runtimes\win-arm64\native" />
+	<file src="..\Output\FFmpegInteropX\ARM64\Release_Desktop\FFmpegInteropX.winmd"   target="runtimes\win-arm64\native" />
+    <file src="..\Output\FFmpegInteropX\ARM64\Release_Desktop\FFmpegInteropX.xml"     target="runtimes\win-arm64\native" />
 
     <file src="FFmpegInteropX.Desktop.Lib.targets"                                  target="build\native"/>
 

--- a/Build/FFmpegInteropX.Desktop.Lib.targets
+++ b/Build/FFmpegInteropX.Desktop.Lib.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\FFmpegInteropX.winmd">
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(PlatformTarget)\native\FFmpegInteropX.winmd">
       <Implementation>FFmpegInteropX.dll</Implementation>
     </Reference>
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(PlatformTarget)\native\*.dll" />

--- a/Build/FFmpegInteropX.UWP.Lib.nuspec
+++ b/Build/FFmpegInteropX.UWP.Lib.nuspec
@@ -16,8 +16,8 @@
   </metadata>
   <files>
 
-    <file src="..\Output\FFmpegInteropX\x64\Release_UWP\FFmpegInteropX.winmd"   target="lib\uap10.0.17763.0" />
-    <file src="..\Output\FFmpegInteropX\x64\Release_UWP\FFmpegInteropX.xml"     target="lib\uap10.0.17763.0" />
+    <file src="..\Output\FFmpegInteropX\x64\Release_UWP\FFmpegInteropX.winmd"   target="lib\uap10" />
+    <file src="..\Output\FFmpegInteropX\x64\Release_UWP\FFmpegInteropX.xml"     target="lib\uap10" />
 
     <file src="..\Output\FFmpegInteropX\x86\Release_UWP\FFmpegInteropX.dll"     target="runtimes\win10-x86\native" />
     <file src="..\Output\FFmpegInteropX\x86\Release_UWP\FFmpegInteropX.pdb"     target="runtimes\win10-x86\native" />

--- a/Build/FFmpegInteropX.UWP.Lib.targets
+++ b/Build/FFmpegInteropX.UWP.Lib.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\FFmpegInteropX.winmd">
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0.17763.0\FFmpegInteropX.winmd">
       <Implementation>FFmpegInteropX.dll</Implementation>
     </Reference>
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(PlatformTarget)\native\*.dll" />

--- a/Build/FFmpegInteropX.UWP.Lib.targets
+++ b/Build/FFmpegInteropX.UWP.Lib.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0.17763.0\FFmpegInteropX.winmd">
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10\FFmpegInteropX.winmd">
       <Implementation>FFmpegInteropX.dll</Implementation>
     </Reference>
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-$(PlatformTarget)\native\*.dll" />

--- a/Samples/MediaPlayerWinUI/MediaPlayerWinUI.csproj
+++ b/Samples/MediaPlayerWinUI/MediaPlayerWinUI.csproj
@@ -30,7 +30,7 @@
   
   <ItemGroup>
     <PackageReference Include="FFmpegInteropX.Desktop.FFmpeg" Version="7.0.100-pre3" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
     <Manifest Include="$(ApplicationManifest)" />

--- a/Source/FFmpegInteropX.DotNet.csproj
+++ b/Source/FFmpegInteropX.DotNet.csproj
@@ -24,6 +24,10 @@
   <PropertyGroup>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <CsWinRTGenerateAotProjection>true</CsWinRTGenerateAotProjection>
+  </PropertyGroup>
   
   <PropertyGroup>
     <DefaultItemExcludes>**\*;*.*</DefaultItemExcludes>
@@ -34,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.3" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
   </ItemGroup>
 
   <Choose>

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -46,10 +46,9 @@ namespace winrt::FFmpegInteropX::implementation
     std::mutex isRegisteredMutex;
 
     FFmpegMediaSource::FFmpegMediaSource(winrt::com_ptr<MediaSourceConfig> const& interopConfig,
-        DispatcherQueue const& dispatcher, uint64_t windowId, bool useHdr)
+         uint64_t windowId, bool useHdr)
         : config(interopConfig)
         , isFirstSeek(true)
-        , dispatcher(dispatcher)
         , windowId(windowId)
         , useHdr(useHdr)
     {
@@ -87,11 +86,10 @@ namespace winrt::FFmpegInteropX::implementation
     winrt::com_ptr<FFmpegMediaSource> FFmpegMediaSource::CreateFromStream(
         IRandomAccessStream const& stream,
         winrt::com_ptr<MediaSourceConfig> const& config,
-        DispatcherQueue const& dispatcher,
         uint64_t windowId,
         bool useHdr)
     {
-        auto interopMSS = winrt::make_self<FFmpegMediaSource>(config, dispatcher, windowId, useHdr);
+        auto interopMSS = winrt::make_self<FFmpegMediaSource>(config, windowId, useHdr);
         auto hr = interopMSS->CreateMediaStreamSource(stream);
         if (!SUCCEEDED(hr))
         {
@@ -103,11 +101,10 @@ namespace winrt::FFmpegInteropX::implementation
     winrt::com_ptr<FFmpegMediaSource> FFmpegMediaSource::CreateFromUri(
         hstring const& uri,
         winrt::com_ptr<MediaSourceConfig> const& config,
-        DispatcherQueue const& dispatcher,
         uint64_t windowId,
         bool useHdr)
     {
-        auto interopMSS = winrt::make_self<FFmpegMediaSource>(config, dispatcher, windowId, useHdr);
+        auto interopMSS = winrt::make_self<FFmpegMediaSource>(config, windowId, useHdr);
         auto hr = interopMSS->CreateMediaStreamSource(uri);
         if (!SUCCEEDED(hr))
         {
@@ -357,12 +354,11 @@ namespace winrt::FFmpegInteropX::implementation
         IRandomAccessStream stream, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId)
     {
         winrt::apartment_context caller; // Capture calling context.
-        auto dispatcher = GetCurrentDispatcherQueue();
         auto configImpl = config.as<winrt::FFmpegInteropX::implementation::MediaSourceConfig>();
         bool useHdr = false;
-        CheckUseHdr(configImpl, dispatcher != nullptr, useHdr, windowId);
+        CheckUseHdr(configImpl, IsOnUIThread(), useHdr, windowId);
         co_await winrt::resume_background();
-        auto result = CreateFromStream(stream, configImpl, dispatcher, windowId, useHdr);
+        auto result = CreateFromStream(stream, configImpl, windowId, useHdr);
         co_await caller;
         co_return result.as<FFmpegInteropX::FFmpegMediaSource>();
     }
@@ -371,26 +367,25 @@ namespace winrt::FFmpegInteropX::implementation
         hstring uri, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId)
     {
         winrt::apartment_context caller; // Capture calling context.
-        auto dispatcher = GetCurrentDispatcherQueue();
         auto configImpl = config.as<winrt::FFmpegInteropX::implementation::MediaSourceConfig>();
         bool useHdr = false;
-        CheckUseHdr(configImpl, dispatcher != nullptr, useHdr, windowId);
+        CheckUseHdr(configImpl, IsOnUIThread(), useHdr, windowId);
         co_await winrt::resume_background();
-        auto result = CreateFromUri(uri, configImpl, dispatcher, windowId, useHdr);
+        auto result = CreateFromUri(uri, configImpl, windowId, useHdr);
         co_await caller;
         co_return result.as<FFmpegInteropX::FFmpegMediaSource>();
     }
 
-    DispatcherQueue FFmpegMediaSource::GetCurrentDispatcherQueue()
+    bool FFmpegMediaSource::IsOnUIThread()
     {
 #ifdef Win32
         if (PlatformInfo::IsWinUI())
         {
-            return DispatcherQueue::GetForCurrentThread();
+            return DispatcherQueue::GetForCurrentThread() != nullptr;
         }
-        return nullptr;
+        return winrt::Windows::System::DispatcherQueue::GetForCurrentThread() != nullptr;
 #else
-        return DispatcherQueue::GetForCurrentThread();
+        return DispatcherQueue::GetForCurrentThread() != nullptr;
 #endif
     }
 
@@ -813,11 +808,11 @@ namespace winrt::FFmpegInteropX::implementation
                     {
                         if ((avSubsCodecCtx->codec_descriptor->props & AV_CODEC_PROP_TEXT_SUB) == AV_CODEC_PROP_TEXT_SUB)
                         {
-                            avSubsStream = std::shared_ptr<SubtitleProvider>(new SubtitleProviderSsaAss(m_pReader, avFormatCtx, avSubsCodecCtx, config.as<winrt::FFmpegInteropX::MediaSourceConfig>(), index, dispatcher, attachedFileHelper));
+                            avSubsStream = std::shared_ptr<SubtitleProvider>(new SubtitleProviderSsaAss(m_pReader, avFormatCtx, avSubsCodecCtx, config.as<winrt::FFmpegInteropX::MediaSourceConfig>(), index, attachedFileHelper));
                         }
                         else if ((avSubsCodecCtx->codec_descriptor->props & AV_CODEC_PROP_BITMAP_SUB) == AV_CODEC_PROP_BITMAP_SUB)
                         {
-                            avSubsStream = std::shared_ptr<SubtitleProvider>(new SubtitleProviderBitmap(m_pReader, avFormatCtx, avSubsCodecCtx, config.as<winrt::FFmpegInteropX::MediaSourceConfig>(), index, dispatcher));
+                            avSubsStream = std::shared_ptr<SubtitleProvider>(new SubtitleProviderBitmap(m_pReader, avFormatCtx, avSubsCodecCtx, config.as<winrt::FFmpegInteropX::MediaSourceConfig>(), index));
                         }
                         else
                         {
@@ -1474,7 +1469,7 @@ namespace winrt::FFmpegInteropX::implementation
             subConfig->AdditionalFFmpegSubtitleOptions.Insert(L"subfps",
                 winrt::box_value(winrt::to_hstring(videoDescriptor.EncodingProperties().FrameRate().Numerator()) + L"/" + winrt::to_hstring(videoDescriptor.EncodingProperties().FrameRate().Denominator())));
         }
-        auto externalSubsParser = FFmpegMediaSource::CreateFromStream(stream, subConfig, dispatcher, windowId, useHdr);
+        auto externalSubsParser = FFmpegMediaSource::CreateFromStream(stream, subConfig, windowId, useHdr);
 
         if (externalSubsParser->SubtitleStreams().Size() > 0)
         {
@@ -1509,7 +1504,7 @@ namespace winrt::FFmpegInteropX::implementation
         co_await winrt::resume_background();
         auto videoDescriptor = currentVideoStream ? (currentVideoStream->StreamDescriptor()).as<VideoStreamDescriptor>() : nullptr;
 
-        auto externalSubsParser = (co_await ReadExternalSubtitleStreamAsync(stream, streamName, config.as<winrt::FFmpegInteropX::MediaSourceConfig>(), videoDescriptor, dispatcher, windowId, useHdr)).as<winrt::FFmpegInteropX::implementation::FFmpegMediaSource>();
+        auto externalSubsParser = (co_await ReadExternalSubtitleStreamAsync(stream, streamName, config.as<winrt::FFmpegInteropX::MediaSourceConfig>(), videoDescriptor, nullptr, windowId, useHdr)).as<winrt::FFmpegInteropX::implementation::FFmpegMediaSource>();
 
         Collections::IVectorView<FFmpegInteropX::SubtitleStreamInfo> result;
         {
@@ -1895,14 +1890,14 @@ namespace winrt::FFmpegInteropX::implementation
 #ifdef Win32
                     if (PlatformInfo::IsWinUI())
                     {
-                        Win32CheckHdr(windowId, useHdr);
+                        useHdr = Win32CheckHdr(windowId);
                     }
                     else
                     {
-                        UwpCheckUseHdr(windowId, useHdr);
+                        useHdr = UwpCheckUseHdr(windowId);
                     }
 #else // UWP
-                    UwpCheckUseHdr(windowId, useHdr);
+                    useHdr = UwpCheckUseHdr(windowId);
 #endif // Win32
                 }
                 catch (...)
@@ -1914,10 +1909,10 @@ namespace winrt::FFmpegInteropX::implementation
             break;
         }
     }
-   
+
 #ifdef Win32
 
-    void FFmpegMediaSource::Win32CheckHdr(uint64_t& windowId, bool& useHdr)
+    bool FFmpegMediaSource::Win32CheckHdr(uint64_t& windowId)
     {
         if (windowId)
         {
@@ -1928,16 +1923,18 @@ namespace winrt::FFmpegInteropX::implementation
                 auto colorInfo = displayInfo.GetAdvancedColorInfo();
                 if (colorInfo.CurrentAdvancedColorKind() == Microsoft::Graphics::Display::DisplayAdvancedColorKind::HighDynamicRange)
                 {
-                    useHdr = true;
+                    return true;
                 }
             }
         }
+
+        return false;
     }
 
 #endif //Win32
 
 
-    void FFmpegMediaSource::UwpCheckUseHdr(uint64_t& windowId, bool& useHdr)
+    bool FFmpegMediaSource::UwpCheckUseHdr(uint64_t& windowId)
     {
         UNREFERENCED_PARAMETER(windowId);
 
@@ -1950,7 +1947,7 @@ namespace winrt::FFmpegInteropX::implementation
                 auto currentDisplayMode = hdmiDisplayInfo.GetCurrentDisplayMode();
                 if (currentDisplayMode && currentDisplayMode.ColorSpace() == Windows::Graphics::Display::Core::HdmiDisplayColorSpace::BT2020)
                 {
-                    useHdr = true;
+                    return true;
                 }
             }
         }
@@ -1962,10 +1959,12 @@ namespace winrt::FFmpegInteropX::implementation
                 auto colorInfo = displayInfo.GetAdvancedColorInfo();
                 if (colorInfo.CurrentAdvancedColorKind() == Windows::Graphics::Display::AdvancedColorKind::HighDynamicRange)
                 {
-                    useHdr = true;
+                    return true;
                 }
             }
         }
+
+        return false;
     }
 
     std::shared_ptr<MediaSampleProvider> FFmpegMediaSource::CreateVideoSampleProvider(AVStream* avStream, AVCodecContext* avVideoCodecCtx, int index)

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -1893,47 +1893,16 @@ namespace winrt::FFmpegInteropX::implementation
                 try
                 {
 #ifdef Win32
-                    if (windowId)
+                    if (PlatformInfo::IsWinUI())
                     {
-                        Microsoft::UI::WindowId id{ windowId };
-                        auto displayInfo = Microsoft::Graphics::Display::DisplayInformation::CreateForWindowId(id);
-                        if (displayInfo)
-                        {
-                            auto colorInfo = displayInfo.GetAdvancedColorInfo();
-                            if (colorInfo.CurrentAdvancedColorKind() == Microsoft::Graphics::Display::DisplayAdvancedColorKind::HighDynamicRange)
-                            {
-                                useHdr = true;
-                            }
-                        }
-                    }
-#else // UWP
-                    UNREFERENCED_PARAMETER(windowId);
-
-                    if (PlatformInfo::IsXbox())
-                    {
-                        // HdmiDisplayInformation is xbox only, DisplayInformation is non-xbox only, each being null in the other case
-                        auto hdmiDisplayInfo = Windows::Graphics::Display::Core::HdmiDisplayInformation::GetForCurrentView();
-                        if (hdmiDisplayInfo)
-                        {
-                            auto currentDisplayMode = hdmiDisplayInfo.GetCurrentDisplayMode();
-                            if (currentDisplayMode && currentDisplayMode.ColorSpace() == Windows::Graphics::Display::Core::HdmiDisplayColorSpace::BT2020)
-                            {
-                                useHdr = true;
-                            }
-                        }
+                        Win32CheckHdr(windowId, useHdr);
                     }
                     else
                     {
-                        auto displayInfo = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
-                        if (displayInfo)
-                        {
-                            auto colorInfo = displayInfo.GetAdvancedColorInfo();
-                            if (colorInfo.CurrentAdvancedColorKind() == Windows::Graphics::Display::AdvancedColorKind::HighDynamicRange)
-                            {
-                                useHdr = true;
-                            }
-                        }
+                        UwpCheckUseHdr(windowId, useHdr);
                     }
+#else // UWP
+                    UwpCheckUseHdr(windowId, useHdr);
 #endif // Win32
                 }
                 catch (...)
@@ -1943,6 +1912,59 @@ namespace winrt::FFmpegInteropX::implementation
             break;
         default:
             break;
+        }
+    }
+   
+#ifdef Win32
+
+    void FFmpegMediaSource::Win32CheckHdr(uint64_t& windowId, bool& useHdr)
+    {
+        if (windowId)
+        {
+            Microsoft::UI::WindowId id{ windowId };
+            auto displayInfo = Microsoft::Graphics::Display::DisplayInformation::CreateForWindowId(id);
+            if (displayInfo)
+            {
+                auto colorInfo = displayInfo.GetAdvancedColorInfo();
+                if (colorInfo.CurrentAdvancedColorKind() == Microsoft::Graphics::Display::DisplayAdvancedColorKind::HighDynamicRange)
+                {
+                    useHdr = true;
+                }
+            }
+        }
+    }
+
+#endif //Win32
+
+
+    void FFmpegMediaSource::UwpCheckUseHdr(uint64_t& windowId, bool& useHdr)
+    {
+        UNREFERENCED_PARAMETER(windowId);
+
+        if (PlatformInfo::IsXbox())
+        {
+            // HdmiDisplayInformation is xbox only, DisplayInformation is non-xbox only, each being null in the other case
+            auto hdmiDisplayInfo = Windows::Graphics::Display::Core::HdmiDisplayInformation::GetForCurrentView();
+            if (hdmiDisplayInfo)
+            {
+                auto currentDisplayMode = hdmiDisplayInfo.GetCurrentDisplayMode();
+                if (currentDisplayMode && currentDisplayMode.ColorSpace() == Windows::Graphics::Display::Core::HdmiDisplayColorSpace::BT2020)
+                {
+                    useHdr = true;
+                }
+            }
+        }
+        else
+        {
+            auto displayInfo = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
+            if (displayInfo)
+            {
+                auto colorInfo = displayInfo.GetAdvancedColorInfo();
+                if (colorInfo.CurrentAdvancedColorKind() == Windows::Graphics::Display::AdvancedColorKind::HighDynamicRange)
+                {
+                    useHdr = true;
+                }
+            }
         }
     }
 

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -235,6 +235,10 @@ namespace winrt::FFmpegInteropX::implementation
         void InitializePlaybackItem(MediaPlaybackItem  const& playbackitem);
         bool CheckUseHardwareAcceleration(AVCodecContext* avCodecCtx, HardwareAccelerationStatus const& status, HardwareDecoderStatus& hardwareDecoderStatus, int maxProfile, int maxLevel);
         static void CheckUseHdr(winrt::com_ptr<MediaSourceConfig> const& config, bool checkDisplayInformation, bool& useHdr, uint64_t& windowId);
+#ifdef Win32
+        static void Win32CheckHdr(uint64_t& windowId, bool& useHdr);
+#endif
+        static void UwpCheckUseHdr(uint64_t& windowId, bool& useHdr);
         void CheckExtendDuration(MediaStreamSample sample);
         MediaThumbnailData ExtractThumbnail(AVStream* avStream);
 

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -210,7 +210,7 @@ namespace winrt::FFmpegInteropX::implementation
 
         void Close();
 
-        FFmpegMediaSource(winrt::com_ptr<MediaSourceConfig> const& interopConfig, DispatcherQueue const& dispatcher, uint64_t windowId, bool useHdr);
+        FFmpegMediaSource(winrt::com_ptr<MediaSourceConfig> const& interopConfig, uint64_t windowId, bool useHdr);
 
     private:
 
@@ -236,21 +236,21 @@ namespace winrt::FFmpegInteropX::implementation
         bool CheckUseHardwareAcceleration(AVCodecContext* avCodecCtx, HardwareAccelerationStatus const& status, HardwareDecoderStatus& hardwareDecoderStatus, int maxProfile, int maxLevel);
         static void CheckUseHdr(winrt::com_ptr<MediaSourceConfig> const& config, bool checkDisplayInformation, bool& useHdr, uint64_t& windowId);
 #ifdef Win32
-        static void Win32CheckHdr(uint64_t& windowId, bool& useHdr);
+        static bool Win32CheckHdr(uint64_t& windowId);
 #endif
-        static void UwpCheckUseHdr(uint64_t& windowId, bool& useHdr);
+        static bool UwpCheckUseHdr(uint64_t& windowId);
         void CheckExtendDuration(MediaStreamSample sample);
         MediaThumbnailData ExtractThumbnail(AVStream* avStream);
 
         void Close(bool onMediaSourceClosed);
-        static DispatcherQueue GetCurrentDispatcherQueue();
+        static bool IsOnUIThread();
 
     public://internal:
         static IAsyncOperation<winrt::FFmpegInteropX::FFmpegMediaSource> ReadExternalSubtitleStreamAsync(IRandomAccessStream stream, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig const& config, VideoStreamDescriptor videoDescriptor, DispatcherQueue dispatcher, uint64_t windowId, bool useHdr);
         static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromStreamInternalAsync(IRandomAccessStream stream, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId);
         static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromUriInternalAsync(hstring uri, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId);
-        static winrt::com_ptr<FFmpegMediaSource> CreateFromStream(IRandomAccessStream const& stream, winrt::com_ptr<MediaSourceConfig> const& config, DispatcherQueue  const& dispatcher, uint64_t windowId, bool useHdr);
-        static winrt::com_ptr<FFmpegMediaSource> CreateFromUri(hstring  const& uri, winrt::com_ptr<MediaSourceConfig>  const& config, DispatcherQueue  const& dispatcher, uint64_t windowId, bool useHdr);
+        static winrt::com_ptr<FFmpegMediaSource> CreateFromStream(IRandomAccessStream const& stream, winrt::com_ptr<MediaSourceConfig> const& config, uint64_t windowId, bool useHdr);
+        static winrt::com_ptr<FFmpegMediaSource> CreateFromUri(hstring  const& uri, winrt::com_ptr<MediaSourceConfig>  const& config, uint64_t windowId, bool useHdr);
         HRESULT Seek(TimeSpan const& position, TimeSpan& actualPosition, bool allowFastSeek);
 
         std::shared_ptr<MediaSampleProvider> VideoSampleProvider()
@@ -308,7 +308,6 @@ namespace winrt::FFmpegInteropX::implementation
         MediaThumbnailData thumbnailData = nullptr;
 
         std::recursive_mutex mutex;
-        DispatcherQueue dispatcher = { nullptr };
         winrt::weak_ref<MediaPlaybackSession> sessionWeak = { nullptr };
         winrt::event_token sessionPositionEvent{};
 

--- a/Source/FrameGrabber.cpp
+++ b/Source/FrameGrabber.cpp
@@ -14,7 +14,7 @@ namespace winrt::FFmpegInteropX::implementation
         config->IsFrameGrabber = true;
         config->Video().VideoDecoderMode(VideoDecoderMode::ForceFFmpegSoftwareDecoder);
 
-        auto result = FFmpegMediaSource::CreateFromStream(stream, config, nullptr, 0, false);
+        auto result = FFmpegMediaSource::CreateFromStream(stream, config,  0, false);
         if (result == nullptr)
         {
             throw_hresult(E_FAIL);// ref new Exception(E_FAIL, "Could not create MediaStreamSource.");
@@ -36,7 +36,7 @@ namespace winrt::FFmpegInteropX::implementation
         config->IsFrameGrabber = true;
         config->Video().VideoDecoderMode(VideoDecoderMode::ForceFFmpegSoftwareDecoder);
 
-        auto result = FFmpegMediaSource::CreateFromUri(uri, config, nullptr, 0, false);
+        auto result = FFmpegMediaSource::CreateFromUri(uri, config,  0, false);
         if (result == nullptr)
         {
             throw_hresult(E_FAIL);

--- a/Source/SubtitleProvider.h
+++ b/Source/SubtitleProvider.h
@@ -32,15 +32,13 @@ public:
         AVCodecContext* avCodecCtx,
         MediaSourceConfig const& config,
         int index,
-        TimedMetadataKind const& ptimedMetadataKind,
-        DispatcherQueue const& pdispatcher)
+        TimedMetadataKind const& ptimedMetadataKind)
         : CompressedSampleProvider(reader,
             avFormatCtx,
             avCodecCtx,
             config,
             index,
             HardwareDecoderStatus::Unknown),
-        dispatcher(pdispatcher),
         timedMetadataKind(ptimedMetadataKind)
     {
     }
@@ -471,8 +469,6 @@ private:
 
     int cueCount = 0;
     TimedMetadataKind timedMetadataKind;
-    DispatcherQueue dispatcher = { nullptr };
-    DispatcherQueueTimer timer = { nullptr };
     TimeSpan actualSubtitleDelay{};
     std::vector<std::pair<IMediaCue, long long>> negativePositionCues;
     IMediaCue infiniteDurationCue = { nullptr };

--- a/Source/SubtitleProviderBitmap.h
+++ b/Source/SubtitleProviderBitmap.h
@@ -20,9 +20,8 @@ public:
         AVFormatContext* avFormatCtx,
         AVCodecContext* avCodecCtx,
         MediaSourceConfig const& config,
-        int index,
-        DispatcherQueue const& dispatcher)
-        : SubtitleProvider(reader, avFormatCtx, avCodecCtx, config, index, TimedMetadataKind::ImageSubtitle, dispatcher)
+        int index)
+        : SubtitleProvider(reader, avFormatCtx, avCodecCtx, config, index, TimedMetadataKind::ImageSubtitle)
     {
     }
 

--- a/Source/SubtitleProviderSsaAss.h
+++ b/Source/SubtitleProviderSsaAss.h
@@ -22,15 +22,13 @@ public:
         AVCodecContext* avCodecCtx,
         MediaSourceConfig const& config,
         int index,
-        DispatcherQueue const& dispatcher,
         std::shared_ptr<AttachedFileHelper> attachedFileHelper)
         : SubtitleProvider(reader,
             avFormatCtx,
             avCodecCtx,
             config,
             index,
-            TimedMetadataKind::Subtitle,
-            dispatcher
+            TimedMetadataKind::Subtitle
         )
     {
         this->attachedFileHelper = attachedFileHelper;

--- a/Tests/FFmpegInteropX.UnitTests.csproj
+++ b/Tests/FFmpegInteropX.UnitTests.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="FFmpegInteropX.Desktop.FFmpeg" Version="7.0.100-pre3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.7" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.3" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />


### PR DESCRIPTION
Normalizes the cswinrt versions installed and updates to latest one.
Enables native AOT support in cswinrt.
Fixes some typo in the build overall package command
Attempts to add support for dotnet 9 UWP 


