### PR TITLE
Add support for IInputStream in media source and frame grabber

### DIFF
--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -25,7 +25,7 @@ param(
         10.0.17763.0
         10.0.18362.0
     #>
-    [version] $WindowsTargetPlatformVersion = '10.0.22000.0',
+    [version] $WindowsTargetPlatformVersion = '10.0.26100.0',
 
     [ValidateSet('Debug', 'Release')]
     [string] $Configuration = 'Release',

--- a/Build-FFmpegInteropX.ps1
+++ b/Build-FFmpegInteropX.ps1
@@ -22,7 +22,7 @@ param(
         10.0.17763.0
         10.0.18362.0
     #>
-    [version] $WindowsTargetPlatformVersion = '10.0.22000.0',
+    [version] $WindowsTargetPlatformVersion = '10.0.26100.0',
 
     [ValidateSet('UWP', 'Desktop')]
     [string] $WindowsTarget = 'UWP',

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion Condition="'$(WindowsTargetPlatformMinVersion)' == ''">10.0.17763.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -357,6 +357,9 @@ namespace FFmpegInteropX
         /// <summary>Creates a new FrameGrabber from the specified stream.</summary>
         static Windows.Foundation.IAsyncOperation<FrameGrabber> CreateFromStreamAsync(Windows.Storage.Streams.IRandomAccessStream stream);
 
+        /// <summary>Creates a new FrameGrabber from the specified input stream.</summary>
+        static Windows.Foundation.IAsyncOperation<FrameGrabber> CreateFromInputStreamAsync(Windows.Storage.Streams.IInputStream stream);
+
         /// <summary>Creates a new FrameGrabber from the specified uri.</summary>
         static Windows.Foundation.IAsyncOperation<FrameGrabber> CreateFromUriAsync(String uri);
 
@@ -427,6 +430,9 @@ namespace FFmpegInteropX
         ///<summary>Creates a FFmpegMediaSource from a stream.</summary>
         static Windows.Foundation.IAsyncOperation<FFmpegMediaSource> CreateFromStreamAsync(Windows.Storage.Streams.IRandomAccessStream stream, MediaSourceConfig config, UInt64 windowId);
 
+        ///<summary>Creates a FFmpegMediaSource from a input stream.</summary>
+        static Windows.Foundation.IAsyncOperation<FFmpegMediaSource> CreateFromInputStreamAsync(Windows.Storage.Streams.IInputStream stream, MediaSourceConfig config, UInt64 windowId);
+
         ///<summary>Creates a FFmpegMediaSource from a Uri.</summary>
         static Windows.Foundation.IAsyncOperation<FFmpegMediaSource> CreateFromUriAsync(String uri, MediaSourceConfig config, UInt64 windowId);
 
@@ -440,6 +446,12 @@ namespace FFmpegInteropX
 
         ///<summary>Creates a FFmpegMediaSource from a stream.</summary>
         static Windows.Foundation.IAsyncOperation<FFmpegMediaSource> CreateFromStreamAsync(Windows.Storage.Streams.IRandomAccessStream stream);
+
+        ///<summary>Creates a FFmpegMediaSource from a input stream.</summary>
+        static Windows.Foundation.IAsyncOperation<FFmpegMediaSource> CreateFromInputStreamAsync(Windows.Storage.Streams.IInputStream stream, MediaSourceConfig config);
+
+        ///<summary>Creates a FFmpegMediaSource from a input stream.</summary>
+        static Windows.Foundation.IAsyncOperation<FFmpegMediaSource> CreateFromInputStreamAsync(Windows.Storage.Streams.IInputStream stream);
 
         ///<summary>Creates a FFmpegMediaSource from a Uri.</summary>
         static Windows.Foundation.IAsyncOperation<FFmpegMediaSource> CreateFromUriAsync(String uri, MediaSourceConfig config);

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -1,13 +1,11 @@
 #include "pch.h"
 #include "FFmpegMediaSource.h"
 #include "LanguageTagConverter.h"
+#include "winrt/impl/Windows.Storage.Streams.0.h"
 #include "FFmpegMediaSource.g.cpp"
-#include "winrt/Windows.ApplicationModel.Core.h"
 #include "D3D11VideoSampleProvider.h"
 #include "H264AVCSampleProvider.h"
 #include "UncompressedAudioSampleProvider.h"
-#include "UncompressedFrameProvider.h"
-#include "UncompressedSampleProvider.h"
 #include "UncompressedVideoSampleProvider.h"
 #include "HEVCSampleProvider.h"
 #include "NALPacketSampleProvider.h"
@@ -15,7 +13,6 @@
 #include "MediaSampleProvider.h"
 #include "SubtitleProviderSsaAss.h"
 #include "SubtitleProviderBitmap.h"
-#include "ChapterInfo.h"
 #include "FFmpegReader.h"
 #include "PlatformInfo.h"
 
@@ -38,6 +35,7 @@ namespace winrt::FFmpegInteropX::implementation
 
     // Static functions passed to FFmpeg
     static int FileStreamRead(void* ptr, uint8_t* buf, int bufSize);
+    static int InputStreamRead(void* ptr, uint8_t* buf, int bufSize);
     static int64_t FileStreamSeek(void* ptr, int64_t pos, int whence);
     static int IsShuttingDown(void* ptr);
 
@@ -98,6 +96,21 @@ namespace winrt::FFmpegInteropX::implementation
         return interopMSS;
     }
 
+    winrt::com_ptr<FFmpegMediaSource> FFmpegMediaSource::CreateFromInputStream(
+        IInputStream const& stream,
+        winrt::com_ptr<MediaSourceConfig> const& config,
+        uint64_t windowId,
+        bool useHdr)
+    {
+        auto interopMSS = winrt::make_self<FFmpegMediaSource>(config, windowId, useHdr);
+        auto hr = interopMSS->CreateMediaStreamSource(stream);
+        if (!SUCCEEDED(hr))
+        {
+            throw_hresult(hr);
+        }
+        return interopMSS;
+    }
+
     winrt::com_ptr<FFmpegMediaSource> FFmpegMediaSource::CreateFromUri(
         hstring const& uri,
         winrt::com_ptr<MediaSourceConfig> const& config,
@@ -145,6 +158,96 @@ namespace winrt::FFmpegInteropX::implementation
         if (SUCCEEDED(hr))
         {
             avIOCtx = avio_alloc_context(fileStreamBuffer, config->General().FileStreamReadSize(), 0, (void*)winrt::get_abi(this), FileStreamRead, 0, FileStreamSeek);
+            if (avIOCtx == nullptr)
+            {
+                av_free(fileStreamBuffer);
+                hr = E_OUTOFMEMORY;
+            }
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            avFormatCtx = avformat_alloc_context();
+            if (avFormatCtx == nullptr)
+            {
+                hr = E_OUTOFMEMORY;
+            }
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            // Populate AVDictionary avDict based on PropertySet ffmpegOptions. List of options can be found in https://www.ffmpeg.org/ffmpeg-protocols.html
+            hr = ParseOptions(config->FFmpegOptions());
+        }
+
+
+        if (SUCCEEDED(hr))
+        {
+            // Populate AVDictionary avDict based on additional ffmpegOptions. List of options can be found in https://www.ffmpeg.org/ffmpeg-protocols.html
+            hr = ParseOptions(config->AdditionalFFmpegSubtitleOptions);
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            // Register callback for fast dispose
+            avFormatCtx->interrupt_callback.callback = IsShuttingDown;
+            avFormatCtx->interrupt_callback.opaque = this;
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            avFormatCtx->pb = avIOCtx;
+            avFormatCtx->flags |= AVFMT_FLAG_CUSTOM_IO;
+            // Open media file using custom IO setup above instead of using file name. Opening a file using file name will invoke fopen C API call that only have
+            // access within the app installation directory and appdata folder. Custom IO allows access to file selected using FilePicker dialog.
+            if (avformat_open_input(&avFormatCtx, "", NULL, &avDict) < 0)
+            {
+                hr = E_FAIL; // Error opening file
+            }
+
+            // avDict is not NULL only when there is an issue with the given ffmpegOptions such as invalid key, value type etc. Iterate through it to see which one is causing the issue.
+            if (avDict != nullptr)
+            {
+                DebugMessage(L"Invalid FFmpeg option(s)");
+                av_dict_free(&avDict);
+
+                avDict = nullptr;
+            }
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            hr = InitFFmpegContext();
+        }
+
+        return hr;
+    }
+
+    HRESULT FFmpegMediaSource::CreateMediaStreamSource(IInputStream const& stream)
+    {
+        HRESULT hr = S_OK;
+        if (!stream)
+        {
+            hr = E_INVALIDARG;
+        }
+
+        inputStream = stream;
+
+        unsigned char* fileStreamBuffer = NULL;
+        if (SUCCEEDED(hr))
+        {
+            // Setup FFmpeg custom IO to access file as stream. This is necessary when accessing any file outside of app installation directory and appdata folder.
+            // Credit to Philipp Sch http://www.codeproject.com/Tips/489450/Creating-Custom-FFmpeg-IO-Context
+            fileStreamBuffer = (unsigned char*)av_malloc(config->General().FileStreamReadSize());
+            if (fileStreamBuffer == nullptr)
+            {
+                hr = E_OUTOFMEMORY;
+            }
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            avIOCtx = avio_alloc_context(fileStreamBuffer, config->General().FileStreamReadSize(), 0, (void*)winrt::get_abi(this), InputStreamRead, 0, 0);
             if (avIOCtx == nullptr)
             {
                 av_free(fileStreamBuffer);
@@ -359,6 +462,19 @@ namespace winrt::FFmpegInteropX::implementation
         CheckUseHdr(configImpl, IsOnUIThread(), useHdr, windowId);
         co_await winrt::resume_background();
         auto result = CreateFromStream(stream, configImpl, windowId, useHdr);
+        co_await caller;
+        co_return result.as<FFmpegInteropX::FFmpegMediaSource>();
+    }
+
+    IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> FFmpegMediaSource::CreateFromInputStreamInternalAsync(
+        IInputStream stream, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId)
+    {
+        winrt::apartment_context caller; // Capture calling context.
+        auto configImpl = config.as<winrt::FFmpegInteropX::implementation::MediaSourceConfig>();
+        bool useHdr = false;
+        CheckUseHdr(configImpl, IsOnUIThread(), useHdr, windowId);
+        co_await winrt::resume_background();
+        auto result = CreateFromInputStream(stream, configImpl, windowId, useHdr);
         co_await caller;
         co_return result.as<FFmpegInteropX::FFmpegMediaSource>();
     }
@@ -2530,6 +2646,54 @@ namespace winrt::FFmpegInteropX::implementation
             return out.QuadPart; // Return the new position:
         }
     }
+
+
+    // Static functions passed to FFmpeg
+    static int InputStreamRead(void* ptr, uint8_t* buf, int bufSize)
+    {
+        FFmpegMediaSource* mss = reinterpret_cast<FFmpegMediaSource*>(ptr);
+        ULONG bytesRead = 0;
+        auto buffer = NativeBuffer::NativeBufferFactory::CreateNativeBuffer(buf, bufSize);
+        auto readFunction = mss->inputStream.ReadAsync(buffer, bufSize, InputStreamOptions::None);
+        auto resultBuffer = readFunction.get();
+
+        // The buffer returned by ReadAsync may not be the same as the one we passed in. In that case, we need to copy the data to our original buffer.
+        if (resultBuffer != buffer)
+        {
+            auto resultData = resultBuffer.data();
+            auto resultSize = resultBuffer.Length();
+            if (resultSize > (ULONG)bufSize)
+            {
+                return -1;
+            }
+            memcpy(buf, resultData, resultSize);
+        }
+        bytesRead = resultBuffer.Length();
+
+        // If we succeed but don't have any bytes, assume end of file
+        if (bytesRead == 0)
+        {
+            return AVERROR_EOF;  // Let FFmpeg know that we have reached eof
+        }
+
+        // Check encoding in case of external subtitle parser
+        if (!mss->streamEncodingChecked && mss->config->IsExternalSubtitleParser && !mss->config->Subtitles().ExternalSubtitleEncoding())
+        {
+            // first check BOM
+            auto encoding = TextEncodingDetect::CheckBOM(buf, bytesRead);
+            if (encoding == TextEncodingDetect::None)
+            {
+                TextEncodingDetect detect;
+                encoding = detect.DetectEncoding(buf, bytesRead);
+            }
+
+            mss->streamEncoding = encoding;
+            mss->streamEncodingChecked = true;
+        }
+
+        return bytesRead;
+    }
+
 
     static int IsShuttingDown(void* ptr)
     {

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -3,16 +3,10 @@
 #include "pch.h"
 #include "MediaSampleProvider.h"
 #include "SubtitleProvider.h"
-#include "AttachedFile.h"
 #include "AttachedFileHelper.h"
 #include "MediaSourceConfig.h"
 #include "CodecChecker.h"
 #include "MediaMetadata.h"
-#include "AudioStreamInfo.h"
-#include "VideoStreamInfo.h"
-#include "SubtitleStreamInfo.h"
-#include "ChapterInfo.h"
-#include "FormatInfo.h"
 #include "text_encoding_detect.h"
 
 namespace winrt::FFmpegInteropX::implementation
@@ -42,6 +36,12 @@ namespace winrt::FFmpegInteropX::implementation
             return CreateFromStreamInternalAsync(stream, config, windowId);
         }
 
+        ///<summary>Creates a FFmpegMediaSource from a input stream.</summary>
+        static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromInputStreamAsync(IInputStream stream, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId)
+        {
+            return CreateFromInputStreamInternalAsync(stream, config, windowId);
+        }
+
         ///<summary>Creates a FFmpegMediaSource from a Uri.</summary>
         static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromUriAsync(hstring uri, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId)
         {
@@ -66,6 +66,18 @@ namespace winrt::FFmpegInteropX::implementation
         static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromStreamAsync(IRandomAccessStream stream)
         {
             return CreateFromStreamInternalAsync(stream, FFmpegInteropX::MediaSourceConfig(), 0);
+        }
+
+        ///<summary>Creates a FFmpegMediaSource from a input stream.</summary>
+        static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromInputStreamAsync(IInputStream stream, FFmpegInteropX::MediaSourceConfig config)
+        {
+            return CreateFromInputStreamInternalAsync(stream, config, 0);
+        }
+
+        ///<summary>Creates a FFmpegMediaSource from a input stream.</summary>
+        static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromInputStreamAsync(IInputStream stream)
+        {
+            return CreateFromInputStreamInternalAsync(stream, FFmpegInteropX::MediaSourceConfig(), 0);
         }
 
         ///<summary>Creates a FFmpegMediaSource from a Uri.</summary>
@@ -215,6 +227,7 @@ namespace winrt::FFmpegInteropX::implementation
     private:
 
         HRESULT CreateMediaStreamSource(IRandomAccessStream const& stream);
+        HRESULT CreateMediaStreamSource(IInputStream const& stream);
         HRESULT CreateMediaStreamSource(hstring const& uri);
         HRESULT InitFFmpegContext();
         MediaStreamSource CreateMediaStreamSource();
@@ -248,8 +261,10 @@ namespace winrt::FFmpegInteropX::implementation
     public://internal:
         static IAsyncOperation<winrt::FFmpegInteropX::FFmpegMediaSource> ReadExternalSubtitleStreamAsync(IRandomAccessStream stream, hstring streamName, winrt::FFmpegInteropX::MediaSourceConfig const& config, VideoStreamDescriptor videoDescriptor, DispatcherQueue dispatcher, uint64_t windowId, bool useHdr);
         static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromStreamInternalAsync(IRandomAccessStream stream, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId);
+        static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromInputStreamInternalAsync(IInputStream stream, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId);
         static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromUriInternalAsync(hstring uri, FFmpegInteropX::MediaSourceConfig config, uint64_t windowId);
         static winrt::com_ptr<FFmpegMediaSource> CreateFromStream(IRandomAccessStream const& stream, winrt::com_ptr<MediaSourceConfig> const& config, uint64_t windowId, bool useHdr);
+        static winrt::com_ptr<FFmpegMediaSource> CreateFromInputStream(IInputStream const& stream, winrt::com_ptr<MediaSourceConfig> const& config, uint64_t windowId, bool useHdr);
         static winrt::com_ptr<FFmpegMediaSource> CreateFromUri(hstring  const& uri, winrt::com_ptr<MediaSourceConfig>  const& config, uint64_t windowId, bool useHdr);
         HRESULT Seek(TimeSpan const& position, TimeSpan& actualPosition, bool allowFastSeek);
 
@@ -263,6 +278,7 @@ namespace winrt::FFmpegInteropX::implementation
         AVIOContext* avIOCtx = nullptr;
         AVFormatContext* avFormatCtx = nullptr;
         winrt::com_ptr<IStream> fileStreamData = { nullptr };
+        IInputStream inputStream = { nullptr };
         TextEncodingDetect::Encoding streamEncoding = TextEncodingDetect::None;
         bool streamEncodingChecked = false;
         winrt::com_ptr<MediaSourceConfig> config = { nullptr };

--- a/Source/FrameGrabber.cpp
+++ b/Source/FrameGrabber.cpp
@@ -14,7 +14,28 @@ namespace winrt::FFmpegInteropX::implementation
         config->IsFrameGrabber = true;
         config->Video().VideoDecoderMode(VideoDecoderMode::ForceFFmpegSoftwareDecoder);
 
-        auto result = FFmpegMediaSource::CreateFromStream(stream, config,  0, false);
+        auto result = FFmpegMediaSource::CreateFromStream(stream, config, 0, false);
+        if (result == nullptr)
+        {
+            throw_hresult(E_FAIL);// ref new Exception(E_FAIL, "Could not create MediaStreamSource.");
+        }
+        if (result->VideoSampleProvider() == nullptr)
+        {
+            throw_hresult(E_INVALIDARG); //S "No video stream found in file (or no suitable decoder available).");
+        }
+        co_await caller;
+        co_return winrt::make<FrameGrabber>(result);
+    }
+
+    IAsyncOperation<FFmpegInteropX::FrameGrabber> FrameGrabber::CreateFromInputStreamAsync(Windows::Storage::Streams::IInputStream stream)
+    {
+        winrt::apartment_context caller; // Capture calling context.
+        co_await winrt::resume_background();
+        auto config = winrt::make_self<MediaSourceConfig>();
+        config->IsFrameGrabber = true;
+        config->Video().VideoDecoderMode(VideoDecoderMode::ForceFFmpegSoftwareDecoder);
+
+        auto result = FFmpegMediaSource::CreateFromInputStream(stream, config, 0, false);
         if (result == nullptr)
         {
             throw_hresult(E_FAIL);// ref new Exception(E_FAIL, "Could not create MediaStreamSource.");

--- a/Source/FrameGrabber.h
+++ b/Source/FrameGrabber.h
@@ -20,6 +20,9 @@ namespace winrt::FFmpegInteropX::implementation
         /// <summary>Creates a new FrameGrabber from the specified stream.</summary>
         static IAsyncOperation<FFmpegInteropX::FrameGrabber> CreateFromStreamAsync(Windows::Storage::Streams::IRandomAccessStream stream);
 
+        /// <summary>Creates a new FrameGrabber from the specified input stream.</summary>
+        static IAsyncOperation<FFmpegInteropX::FrameGrabber> CreateFromInputStreamAsync(Windows::Storage::Streams::IInputStream stream);
+
         /// <summary>Creates a new FrameGrabber from the specified uri.</summary>
         static IAsyncOperation<FFmpegInteropX::FrameGrabber> CreateFromUriAsync(hstring uri);
 


### PR DESCRIPTION
This allows creating media sources and frame grabber from non-seekable IInputStreams.