### PR TITLE
Fix: Report supported playback rate

### DIFF
--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -20,7 +20,6 @@
 #include <winrt/Microsoft.Graphics.Display.h>
 #include <winrt/Microsoft.UI.Xaml.h>
 #include <winrt/Microsoft.UI.Windowing.h>
-#include <winrt/Microsoft.UI.Interop.h>
 #include <winuser.h>
 #else
 #endif
@@ -824,6 +823,13 @@ namespace winrt::FFmpegInteropX::implementation
         }
 
         mss.BufferTime(TimeSpan{ 0 });
+
+        //support playback rate
+        auto maxSupportedPlaybackRate = config->General().MaxSupportedPlaybackRate();
+        if (maxSupportedPlaybackRate > 1.0)
+        {
+            mss.MaxSupportedPlaybackRate(winrt::box_value(maxSupportedPlaybackRate).as<Windows::Foundation::IReference<double>>());
+        }
 
         if (mediaDuration.count() > 0)
         {


### PR DESCRIPTION
I found that in the MediaTransportControl, even after I enabled PlaybackRate, the button is still grayed out. Did some research, and found out the playback rate support is not reported to MediaStreamSource.
This PR adds it, so now the playback speed is adjustable from the MediaTransportControl.

<img width="1545" height="822" alt="image" src="https://github.com/user-attachments/assets/ba923a37-8cdb-46f2-a506-64ac8158dc7a" />
