### PR TITLE
Update lib to cpp20 compiler and fix warnings

### DIFF
--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -13,7 +13,7 @@ param(
 
         Note. The PlatformToolset will be inferred from this value ('v141', 'v142'...)
     #>
-    [version] $VcVersion = '14.3',
+    [version] $VcVersion = '14.5',
 
     [ValidateSet('UWP', 'Desktop')]
     [string] $WindowsTarget = 'UWP',

--- a/Build-FFmpegInteropX.ps1
+++ b/Build-FFmpegInteropX.ps1
@@ -13,7 +13,7 @@ param(
 
         Note. The PlatformToolset will be inferred from this value ('v141', 'v142'...)
     #>
-    [version] $VcVersion = '14.3',
+    [version] $VcVersion = '14.5',
 
     <#
         Example values:

--- a/Build-VideoEffects.ps1
+++ b/Build-VideoEffects.ps1
@@ -13,7 +13,7 @@ param(
 
         Note. The PlatformToolset will be inferred from this value ('v141', 'v142'...)
     #>
-    [version] $VcVersion = '14.3',
+    [version] $VcVersion = '14.5',
 
     <#
         Example values:

--- a/Source/D3D11VideoSampleProvider.h
+++ b/Source/D3D11VideoSampleProvider.h
@@ -384,6 +384,8 @@ public:
         const winrt::com_ptr<IMFDXGIDeviceManager>& deviceManager,
         HANDLE* outDeviceHandle)
     {
+        UNREFERENCED_PARAMETER(sender);
+
         winrt::com_ptr<ID3D11Device> device;
         winrt::com_ptr<ID3D11DeviceContext> deviceContext;
         winrt::com_ptr<ID3D11VideoDevice> videoDevice;

--- a/Source/FFmpegInteropX.vcxproj
+++ b/Source/FFmpegInteropX.vcxproj
@@ -157,7 +157,7 @@
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <DisableSpecificWarnings>28204;4635;4634</DisableSpecificWarnings>
       <GenerateXMLDocumentationFiles>true</GenerateXMLDocumentationFiles>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <SDLCheck>false</SDLCheck>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Debug_Desktop|ARM'">stdc17</LanguageStandard_C>
       <LanguageStandard_C Condition="'$(Configuration)|$(Platform)'=='Debug_UWP|ARM'">stdc17</LanguageStandard_C>

--- a/Source/FFmpegMediaSource.h
+++ b/Source/FFmpegMediaSource.h
@@ -87,7 +87,7 @@ namespace winrt::FFmpegInteropX::implementation
         }
 
         ///<summary>Creates a FFmpegMediaSource from a Uri.</summary>
-        static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> FFmpegMediaSource::CreateFromUriAsync(hstring uri)
+        static IAsyncOperation<FFmpegInteropX::FFmpegMediaSource> CreateFromUriAsync(hstring uri)
         {
             return CreateFromUriInternalAsync(uri, FFmpegInteropX::MediaSourceConfig(), 0);
         }

--- a/Source/MediaSampleProvider.h
+++ b/Source/MediaSampleProvider.h
@@ -113,7 +113,7 @@ public:
     virtual HRESULT SetSampleProperties(winrt::Windows::Media::Core::MediaStreamSample const& sample) { UNREFERENCED_PARAMETER(sample); return S_OK; }; // can be overridded for setting extended properties
     virtual void EnableStream();
     virtual void DisableStream();
-    virtual void SetFFmpegFilters(winrt::hstring ffmpegFilters) { };// override for setting effects in sample providers
+    virtual void SetFFmpegFilters(winrt::hstring ffmpegFilters) { UNREFERENCED_PARAMETER(ffmpegFilters); };// override for setting effects in sample providers
     virtual void ClearFFmpegFilters() {};//override for disabling filters in sample providers;
     virtual winrt::hstring GetFFmpegFilters() { return winrt::hstring{}; }//override to get the current ffmpeg filters
     virtual void SetCommonVideoEncodingProperties(winrt::Windows::Media::MediaProperties::VideoEncodingProperties const& videoEncodingProperties, bool isCompressedFormat);

--- a/Source/SubtitleProviderBitmap.h
+++ b/Source/SubtitleProviderBitmap.h
@@ -131,6 +131,7 @@ private:
 
     void OnCueEntered(TimedMetadataTrack sender, MediaCueEventArgs args)
     {
+        UNREFERENCED_PARAMETER(sender);
         std::lock_guard lock(mutex);
         try
         {
@@ -156,6 +157,7 @@ private:
 
     void OnCueExited(TimedMetadataTrack sender, MediaCueEventArgs args)
     {
+        UNREFERENCED_PARAMETER(sender);
         std::lock_guard lock(mutex);
         try
         {

--- a/Source/UncompressedVideoSampleProvider.cpp
+++ b/Source/UncompressedVideoSampleProvider.cpp
@@ -130,7 +130,8 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
 
     using namespace winrt::Windows::Graphics::Display;
 
-    if (codecPar->color_primaries != AVCOL_PRI_UNSPECIFIED && (codecPar->color_primaries < MFVideoPrimaries_BT2020 || applyHdrColorInfo))
+    bool hasHdrVideoPrimaries = false;
+    if (codecPar->color_primaries != AVCOL_PRI_UNSPECIFIED)
     {
         MFVideoPrimaries videoPrimaries{ MFVideoPrimaries_Unknown };
         switch (codecPar->color_primaries)
@@ -172,10 +173,18 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
             break;
         }
 
-        properties.Insert(MF_MT_VIDEO_PRIMARIES, PropertyValue::CreateUInt32(videoPrimaries));
+        if (videoPrimaries != MFVideoPrimaries_Unknown)
+        {
+            hasHdrVideoPrimaries = videoPrimaries >= MFVideoPrimaries_BT2020;
+            if (!hasHdrVideoPrimaries || applyHdrColorInfo)
+            {
+                properties.Insert(MF_MT_VIDEO_PRIMARIES, PropertyValue::CreateUInt32(videoPrimaries));
+            }
+        }
     }
 
-    if (codecPar->color_trc != AVCOL_TRC_UNSPECIFIED && (codecPar->color_trc < MFVideoTransFunc_2020_const || applyHdrColorInfo))
+    bool hasHdrVideoTransferFunction = false;
+    if (codecPar->color_trc != AVCOL_TRC_UNSPECIFIED)
     {
         MFVideoTransferFunction videoTransferFunc{ MFVideoTransFunc_Unknown };
         switch (codecPar->color_trc)
@@ -227,7 +236,14 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
             break;
         }
 
-        properties.Insert(MF_MT_TRANSFER_FUNCTION, PropertyValue::CreateUInt32(videoTransferFunc));
+        if (videoTransferFunc != MFVideoTransFunc_Unknown)
+        {
+            hasHdrVideoTransferFunction = videoTransferFunc >= MFVideoTransFunc_2020_const;
+            if (!hasHdrVideoTransferFunction || applyHdrColorInfo)
+            {
+                properties.Insert(MF_MT_TRANSFER_FUNCTION, PropertyValue::CreateUInt32(videoTransferFunc));
+            }
+        }
     }
 
     if (codecPar->color_range != AVCOL_RANGE_UNSPECIFIED)
@@ -271,7 +287,7 @@ IMediaStreamDescriptor UncompressedVideoSampleProvider::CreateStreamDescriptor()
         }
     }
 
-    hasHdrMetadata = (masteringDisplayMetadata != nullptr && (masteringDisplayMetadata->has_primaries || masteringDisplayMetadata->has_luminance)) || contentLightMetadata != nullptr || codecPar->color_primaries >= MFVideoPrimaries_BT2020 || codecPar->color_trc >= MFVideoTransFunc_2020_const;
+    hasHdrMetadata = (masteringDisplayMetadata != nullptr && (masteringDisplayMetadata->has_primaries || masteringDisplayMetadata->has_luminance)) || contentLightMetadata != nullptr || hasHdrVideoPrimaries || hasHdrVideoTransferFunction;
     isHdrActive = hasHdrMetadata && applyHdrColorInfo;
 
     videoProperties.Properties().Insert(MF_MT_INTERLACE_MODE, winrt::box_value((UINT32)_MFVideoInterlaceMode::MFVideoInterlace_MixedInterlaceOrProgressive));

--- a/Source/pch.h
+++ b/Source/pch.h
@@ -90,7 +90,7 @@ extern "C"
 template<class T>
 std::vector<T> inline to_vector(IVector<T> input)
 {
-    return to_vector(input.GetView())
+    return to_vector(input.GetView());
 }
 
 template<class T>


### PR DESCRIPTION
Since quite a while, we had a compiler warning beacuse we used co_await with cpp17 compiler. This warning has now changed to error level, so I updated the lib to cpp20.

Some new compiler warnings and errors came up, which I resolved. And in fact, some of the new warnings indeed hinted at errors in our code! Incorrect comparison of ffmpeg enums with MF enums could cause wrong reporting and/or applying of HDR metadata. This is now fixed as well.