### PR TITLE
experimental use of DirectX to detect HDR

### DIFF
--- a/Source/DirectXInteropHelper.cpp
+++ b/Source/DirectXInteropHelper.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "DirectXInteropHelper.h"
 #include <Windows.Graphics.DirectX.Direct3D11.interop.h>
+#include <dxgi1_6.h>
 
 using namespace winrt::Windows::Graphics::DirectX::Direct3D11;
 
@@ -57,4 +58,43 @@ HRESULT DirectXInteropHelper::GetDeviceFromStreamSource(
     }
 
     return hr;
+}
+
+/// <summary>
+/// Verifies if at least one connected monitor supports HDR
+/// </summary>
+/// <returns></returns>
+bool DirectXInteropHelper::CheckConnectedMonitorsForHDR()
+{
+    winrt::com_ptr<IDXGIFactory1> factory;
+    if (FAILED(CreateDXGIFactory1(IID_PPV_ARGS(&factory))))
+    {
+        return false;
+    }
+
+    winrt::com_ptr<IDXGIAdapter1> adapter;
+    UINT adapterIndex = 0;
+
+    while (factory->EnumAdapters1(adapterIndex++, adapter.put()) != DXGI_ERROR_NOT_FOUND)
+    {
+        winrt::com_ptr<IDXGIOutput> output;
+        UINT outputIndex = 0;
+
+        while (adapter->EnumOutputs(outputIndex++, output.put()) != DXGI_ERROR_NOT_FOUND)
+        {
+            winrt::com_ptr<IDXGIOutput6> output6;
+            if (SUCCEEDED(output->QueryInterface(IID_PPV_ARGS(&output6))))
+            {
+                DXGI_OUTPUT_DESC1 desc1;
+                if (SUCCEEDED(output6->GetDesc1(&desc1)))
+                {
+                    if (desc1.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+        }
+    }
 }

--- a/Source/DirectXInteropHelper.h
+++ b/Source/DirectXInteropHelper.h
@@ -8,4 +8,6 @@ public:
     static HRESULT GetDXGISurface(const IDirect3DSurface& source, winrt::com_ptr<IDXGISurface>& dxgiSurface);
     static HRESULT GetDeviceFromStreamSource(const winrt::com_ptr<IMFDXGIDeviceManager>& deviceManager, winrt::com_ptr<ID3D11Device> &outDevice, winrt::com_ptr<ID3D11DeviceContext>& outDeviceContext, winrt::com_ptr<ID3D11VideoDevice>& outVideoDevice, HANDLE* outDeviceHandle);
     static HRESULT GetDeviceManagerFromStreamSource(const winrt::Windows::Media::Core::MediaStreamSource& source, winrt::com_ptr<IMFDXGIDeviceManager>& deviceManager);
+    static bool CheckConnectedMonitorsForHDR();
+
 };

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -43,7 +43,7 @@ namespace winrt::FFmpegInteropX::implementation
     std::mutex isRegisteredMutex;
 
     FFmpegMediaSource::FFmpegMediaSource(winrt::com_ptr<MediaSourceConfig> const& interopConfig,
-         uint64_t windowId, bool useHdr)
+        uint64_t windowId, bool useHdr)
         : config(interopConfig)
         , isFirstSeek(true)
         , windowId(windowId)
@@ -2009,18 +2009,7 @@ namespace winrt::FFmpegInteropX::implementation
             {
                 try
                 {
-#ifdef Win32
-                    if (PlatformInfo::IsWinUI())
-                    {
-                        useHdr = Win32CheckHdr(windowId);
-                    }
-                    else
-                    {
-                        useHdr = UwpCheckUseHdr(windowId);
-                    }
-#else // UWP
                     useHdr = UwpCheckUseHdr(windowId);
-#endif // Win32
                 }
                 catch (...)
                 {
@@ -2032,32 +2021,9 @@ namespace winrt::FFmpegInteropX::implementation
         }
     }
 
-#ifdef Win32
-
-    bool FFmpegMediaSource::Win32CheckHdr(uint64_t& windowId)
-    {
-        if (windowId)
-        {
-            Microsoft::UI::WindowId id{ windowId };
-            auto displayInfo = Microsoft::Graphics::Display::DisplayInformation::CreateForWindowId(id);
-            if (displayInfo)
-            {
-                auto colorInfo = displayInfo.GetAdvancedColorInfo();
-                if (colorInfo.CurrentAdvancedColorKind() == Microsoft::Graphics::Display::DisplayAdvancedColorKind::HighDynamicRange)
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-#endif //Win32
-
-
     bool FFmpegMediaSource::UwpCheckUseHdr(uint64_t& windowId)
     {
+
         UNREFERENCED_PARAMETER(windowId);
 
         if (PlatformInfo::IsXbox())
@@ -2075,15 +2041,8 @@ namespace winrt::FFmpegInteropX::implementation
         }
         else
         {
-            auto displayInfo = Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
-            if (displayInfo)
-            {
-                auto colorInfo = displayInfo.GetAdvancedColorInfo();
-                if (colorInfo.CurrentAdvancedColorKind() == Windows::Graphics::Display::AdvancedColorKind::HighDynamicRange)
-                {
-                    return true;
-                }
-            }
+            return DirectXInteropHelper::CheckConnectedMonitorsForHDR();
+
         }
 
         return false;


### PR DESCRIPTION
So I have long looked for a way to detect HDR using DirectX, and one of the reasons it seemed very difficult is because I simply assumed we need to use the DirectX device handle we get from the MediaStreamSource, which we won't get until the Starting event, which is too late.

But then last night I remembered that many many eons ago, in times forgotten by humanity, when I was playing with hwaccel support, I could create DirectX devices out of thin air and they would be fully functional, except the rendering part (which makes sense, i won't go into too many details).

Now the funny part is that we can, in fact, detect HDR without a window handle. "It works on my machine" under UWP, and I expect it to work for winUI 3 as well, which I will be testing later on. However, since this is very closely tied to drivers and hardware, additional testing may be needed on as many devices as possible. 

Compared to the current implementation which is tied to a window, this detects if any monitor connected to the device potentially supports HDR. In covers some situations better, some situations worse.

This implementation brings us one step closer to getting rid of winUI 3 code and stick to the Windows Universal Contract APIs.
Ideally, we should move towards dynamically detecting if HDR is allowed based on the DirectX device handle we get from the MSS - I am not sure if we can set the HDR metadata after the MediaStreamDescriptors have been set.
I am also not sure if this works on XBox (the bane of our existence). It should work, since this is the same method that games detect HDR, but you never know.

Some additional cleanup is needed, if we decide to go forward with this approach.