### PR TITLE
update to ffmpeg AV-prefix

### DIFF
--- a/Source/AvCodecContextHelpers.h
+++ b/Source/AvCodecContextHelpers.h
@@ -15,12 +15,12 @@ class AvCodecContextHelpers
 public:
     static int GetNBChannels(AVCodecContext* avCodecCtx)
     {
-        return avCodecCtx->profile == FF_PROFILE_AAC_HE_V2 && avCodecCtx->ch_layout.nb_channels == 1 ? 2 : avCodecCtx->ch_layout.nb_channels;
+        return avCodecCtx->profile == AV_PROFILE_AAC_HE_V2 && avCodecCtx->ch_layout.nb_channels == 1 ? 2 : avCodecCtx->ch_layout.nb_channels;
     }
 
     static UINT64 GetChannelLayout(AVCodecContext* avCodecCtx)
     {
-        if (avCodecCtx->profile == FF_PROFILE_AAC_HE_V2 && avCodecCtx->ch_layout.nb_channels == 1)
+        if (avCodecCtx->profile == AV_PROFILE_AAC_HE_V2 && avCodecCtx->ch_layout.nb_channels == 1)
         {
             return AV_CH_LAYOUT_STEREO;
         }

--- a/Source/CodecChecker.h
+++ b/Source/CodecChecker.h
@@ -204,11 +204,11 @@ namespace winrt::FFmpegInteropX::implementation
                             {
                                 hardwareAccelerationH264.IsAvailable = true;
                                 hardwareAccelerationH264.MaxResolution = CheckResolution(profile, videoDevice);
-                                hardwareAccelerationH264.AppendProfile(FF_PROFILE_H264_BASELINE);
-                                hardwareAccelerationH264.AppendProfile(FF_PROFILE_H264_CONSTRAINED_BASELINE);
-                                hardwareAccelerationH264.AppendProfile(FF_PROFILE_H264_EXTENDED);
-                                hardwareAccelerationH264.AppendProfile(FF_PROFILE_H264_MAIN);
-                                hardwareAccelerationH264.AppendProfile(FF_PROFILE_H264_HIGH);
+                                hardwareAccelerationH264.AppendProfile(AV_PROFILE_H264_BASELINE);
+                                hardwareAccelerationH264.AppendProfile(AV_PROFILE_H264_CONSTRAINED_BASELINE);
+                                hardwareAccelerationH264.AppendProfile(AV_PROFILE_H264_EXTENDED);
+                                hardwareAccelerationH264.AppendProfile(AV_PROFILE_H264_MAIN);
+                                hardwareAccelerationH264.AppendProfile(AV_PROFILE_H264_HIGH);
                             }
                             continue;
                         }
@@ -223,11 +223,11 @@ namespace winrt::FFmpegInteropX::implementation
 
                             if (profile == D3D11_DECODER_PROFILE_HEVC_VLD_MAIN)
                             {
-                                hardwareAccelerationHEVC.AppendProfile(FF_PROFILE_HEVC_MAIN, resolution);
+                                hardwareAccelerationHEVC.AppendProfile(AV_PROFILE_HEVC_MAIN, resolution);
                             }
                             else
                             {
-                                hardwareAccelerationHEVC.AppendProfile(FF_PROFILE_HEVC_MAIN_10, resolution);
+                                hardwareAccelerationHEVC.AppendProfile(AV_PROFILE_HEVC_MAIN_10, resolution);
                             }
                             continue;
                         }
@@ -238,8 +238,8 @@ namespace winrt::FFmpegInteropX::implementation
                             if (!hardwareAccelerationMPEG2.IsAvailable)
                             {
                                 hardwareAccelerationMPEG2.IsAvailable = true;
-                                hardwareAccelerationMPEG2.AppendProfile(FF_PROFILE_MPEG2_MAIN);
-                                hardwareAccelerationMPEG2.AppendProfile(FF_PROFILE_MPEG2_SIMPLE);
+                                hardwareAccelerationMPEG2.AppendProfile(AV_PROFILE_MPEG2_MAIN);
+                                hardwareAccelerationMPEG2.AppendProfile(AV_PROFILE_MPEG2_SIMPLE);
                             }
 
                             auto resolution = CheckResolution(profile, videoDevice);
@@ -270,11 +270,11 @@ namespace winrt::FFmpegInteropX::implementation
 
                             if (profile == D3D11_DECODER_PROFILE_VP9_VLD_PROFILE0)
                             {
-                                hardwareAccelerationVP9.AppendProfile(FF_PROFILE_VP9_0, resolution);
+                                hardwareAccelerationVP9.AppendProfile(AV_PROFILE_VP9_0, resolution);
                             }
                             else
                             {
-                                hardwareAccelerationVP9.AppendProfile(FF_PROFILE_VP9_2, resolution);
+                                hardwareAccelerationVP9.AppendProfile(AV_PROFILE_VP9_2, resolution);
                             }
                             continue;
                         }

--- a/Source/FFmpegInteropX.idl
+++ b/Source/FFmpegInteropX.idl
@@ -709,14 +709,14 @@ namespace FFmpegInteropX
         ///<summary>The HDR color support mode. Default is Automatic.</summary>
         HdrSupport HdrSupport{ get; set; };
 
-        ///<summary>Max profile allowed for H264 system decoder. Default: High Profile (100). See FF_PROFILE_H264_* values.</summary>
+        ///<summary>Max profile allowed for H264 system decoder. Default: High Profile (100). See AV_PROFILE_H264_* values.</summary>
         Int32 SystemDecoderH264MaxProfile{ get; set; };
 
         ///<summary>Max level allowed for H264 system decoder. Default: Level 4.1 (41). Use -1 to disable level check.</summary>
         ///<remarks>Most H264 HW decoders only support Level 4.1, so this is the default.</remarks>
         Int32 SystemDecoderH264MaxLevel{ get; set; };
 
-        ///<summary>Max profile allowed for HEVC system decoder. Default: High10 Profile (2). See FF_PROFILE_HEVC_* values.</summary>
+        ///<summary>Max profile allowed for HEVC system decoder. Default: High10 Profile (2). See AV_PROFILE_HEVC_* values.</summary>
         Int32 SystemDecoderHEVCMaxProfile{ get; set; };
 
         ///<summary>Max level allowed for HEVC system decoder. Default: Disabled (-1).</summary>

--- a/Source/FFmpegMediaSource.cpp
+++ b/Source/FFmpegMediaSource.cpp
@@ -2037,7 +2037,7 @@ namespace winrt::FFmpegInteropX::implementation
             }
             else
             {
-                encodingProperties = AudioEncodingProperties::CreateAac(avAudioCodecCtx->profile == FF_PROFILE_AAC_HE || avAudioCodecCtx->profile == FF_PROFILE_AAC_HE_V2 ? avAudioCodecCtx->sample_rate / 2 : avAudioCodecCtx->sample_rate, avAudioCodecCtx->ch_layout.nb_channels, (unsigned int)avAudioCodecCtx->bit_rate);
+                encodingProperties = AudioEncodingProperties::CreateAac(avAudioCodecCtx->profile == AV_PROFILE_AAC_HE || avAudioCodecCtx->profile == AV_PROFILE_AAC_HE_V2 ? avAudioCodecCtx->sample_rate / 2 : avAudioCodecCtx->sample_rate, avAudioCodecCtx->ch_layout.nb_channels, (unsigned int)avAudioCodecCtx->bit_rate);
             }
             audioSampleProvider = std::shared_ptr<MediaSampleProvider>(new CompressedSampleProvider(m_pReader, avFormatCtx, avAudioCodecCtx, config.as<winrt::FFmpegInteropX::MediaSourceConfig>(), index, encodingProperties, HardwareDecoderStatus::Unknown));
         }

--- a/Source/UncompressedAudioSampleProvider.cpp
+++ b/Source/UncompressedAudioSampleProvider.cpp
@@ -51,7 +51,7 @@ winrt::Windows::Media::Core::IMediaStreamDescriptor UncompressedAudioSampleProvi
     auto sampleRate = m_pAvCodecCtx->sample_rate;
 
     auto channelLayout = m_pAvCodecCtx->ch_layout;
-    if (m_pAvCodecCtx->profile == FF_PROFILE_AAC_HE_V2 && channelLayout.nb_channels == 1)
+    if (m_pAvCodecCtx->profile == AV_PROFILE_AAC_HE_V2 && channelLayout.nb_channels == 1)
     {
         channelLayout.nb_channels = 2;
         channelLayout.order = AV_CHANNEL_ORDER_NATIVE;

--- a/Source/VideoConfig.h
+++ b/Source/VideoConfig.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "VideoConfig.g.h"
 #include "ConfigurationCommon.h"
+#include "libavcodec/avcodec.h"
 
 namespace winrt::FFmpegInteropX::implementation
 {
@@ -14,16 +15,16 @@ namespace winrt::FFmpegInteropX::implementation
         ///<summary>Sets the HDR color support mode. Default is Automatic.</summary>
         PROPERTY(HdrSupport, FFmpegInteropX::HdrSupport, HdrSupport::Automatic);
 
-        ///<summary>Max profile allowed for H264 system decoder. Default: High Profile (100). See FF_PROFILE_H264_* values.</summary>
-        PROPERTY(SystemDecoderH264MaxProfile, int32_t, FF_PROFILE_H264_HIGH);
+        ///<summary>Max profile allowed for H264 system decoder. Default: High Profile (100). See AV_PROFILE_H264_* values.</summary>
+        PROPERTY(SystemDecoderH264MaxProfile, int32_t, AV_PROFILE_H264_HIGH);
 
         ///<summary>Max level allowed for H264 system decoder. Default: Level 4.1 (41). Use -1 to disable level check.</summary>
         ///<remarks>Most H264 HW decoders only support Level 4.1, so this is the default.</remarks>
         PROPERTY(SystemDecoderH264MaxLevel, int32_t, 41);
 
 
-        ///<summary>Max profile allowed for HEVC system decoder. Default: High10 Profile (2). See FF_PROFILE_HEVC_* values.</summary>
-        PROPERTY(SystemDecoderHEVCMaxProfile, int32_t, FF_PROFILE_HEVC_MAIN_10);
+        ///<summary>Max profile allowed for HEVC system decoder. Default: High10 Profile (2). See AV_PROFILE_HEVC_* values.</summary>
+        PROPERTY(SystemDecoderHEVCMaxProfile, int32_t, AV_PROFILE_HEVC_MAIN_10);
 
         ///<summary>Max level allowed for HEVC system decoder. Default: Disabled (-1).</summary>
         ///<remarks>Encoded as: 30*Major + 3*Minor. So Level 6.0 = 30*6 = 180, 5.1 = 30*5 + 3*1 = 163, 4.1 = 123.


### PR DESCRIPTION
ffmpeg has already deprecated the FF_PROFILE_* defines, and the new version has removed them.

https://ffmpeg.org/pipermail/ffmpeg-devel/2023-September/313838.html

tested on ffmpeg 7.1 and 8.0