### PR TITLE
Update to ffmpeg 8.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run Build Script
         shell: powershell
         run: |
-          ./Build-FFmpegInteropX.ps1 -Platforms x64
+          ./Build-FFmpegInteropX.ps1 -WindowsTargets UWP -Platforms x64
 
   build_desktop:
     name: Build-FFmpegInteropX Desktop
@@ -50,4 +50,4 @@ jobs:
       - name: Run Build Script
         shell: powershell
         run: |
-          ./Build-FFmpegInteropX.ps1 -WindowsTarget Desktop -Platforms x64
+          ./Build-FFmpegInteropX.ps1 -WindowsTargets Desktop -Platforms x64

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -120,7 +120,9 @@ function Build-Platform {
     
     $env:LIB += ";$build\lib"
     $env:INCLUDE += ";$build\include"
-    $env:Path += ";$SolutionDir\Libs\gas-preprocessor"	
+    $env:Path += ";$SolutionDir\Libs\gas-preprocessor"
+
+    Write-Host "LIB: $env:LIB"
         
     if (! $SkipBuildLibs)
     {

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -153,7 +153,6 @@ function Build-Platform {
 
         ('lib', 'licenses', 'include') | ForEach-Object {
             New-Item -ItemType Directory -Force $build\$_ | Out-Null
-            New-Item -ItemType Directory -Force $target\$_ | Out-Null
         }
 
         # library definitions: <FolderName>, <ProjectName>, <FFmpegTargetName> 
@@ -518,7 +517,7 @@ if ($AllowParallelBuilds -and $Platforms.Count -gt 1)
         {
             $skip
         }
-        $proc = Start-Process -PassThru powershell "-File .\Build-FFmpeg.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformMinVersion -WindowsTargetPlatformMinVersion $WindowsTargetPlatformVersion -Configuration $Configuration -SharedOrStatic $SharedOrStatic -Gpl $Gpl -Encoders $Encoders -Devices $Devices -Programs $Programs -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -BashExe ""$BashExe"" $clear -FFmpegUrl $FFmpegUrl -FFmpegCommit $FFmpegCommit $skipPkgConfig $addparams"
+        $proc = Start-Process -PassThru powershell "-File .\Build-FFmpeg.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion -Configuration $Configuration -SharedOrStatic $SharedOrStatic -Gpl $Gpl -Encoders $Encoders -Devices $Devices -Programs $Programs -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -BashExe ""$BashExe"" $clear -FFmpegUrl $FFmpegUrl -FFmpegCommit $FFmpegCommit $skipPkgConfig $addparams"
         $processes[$platform] = $proc
     
         # only build PkgConfigFake once

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -27,6 +27,15 @@ param(
     #>
     [version] $WindowsTargetPlatformVersion = '10.0.26100.0',
 
+    <#
+        Example values:
+        8.1
+        10.0.15063.0
+        10.0.17763.0
+        10.0.18362.0
+    #>
+    [version] $WindowsTargetPlatformMinVersion = '10.0.17763.0',
+
     [ValidateSet('Debug', 'Release')]
     [string] $Configuration = 'Release',
     
@@ -184,6 +193,7 @@ function Build-Platform {
                 /p:Configuration=$configurationName `
                 /p:Platform=$Platform `
                 /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+                /p:WindowsTargetPlatformMinVersion=$WindowsTargetPlatformMinVersion `
                 /p:PlatformToolset=$PlatformToolset `
                 /p:ForceImportBeforeCppTargets=$SolutionDir\Libs\build-scripts\LibOverrides.props `
                 /p:useenv=true
@@ -508,7 +518,7 @@ if ($AllowParallelBuilds -and $Platforms.Count -gt 1)
         {
             $skip
         }
-        $proc = Start-Process -PassThru powershell "-File .\Build-FFmpeg.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -Configuration $Configuration -SharedOrStatic $SharedOrStatic -Gpl $Gpl -Encoders $Encoders -Devices $Devices -Programs $Programs -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -BashExe ""$BashExe"" $clear -FFmpegUrl $FFmpegUrl -FFmpegCommit $FFmpegCommit $skipPkgConfig $addparams"
+        $proc = Start-Process -PassThru powershell "-File .\Build-FFmpeg.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformMinVersion -WindowsTargetPlatformMinVersion $WindowsTargetPlatformVersion -Configuration $Configuration -SharedOrStatic $SharedOrStatic -Gpl $Gpl -Encoders $Encoders -Devices $Devices -Programs $Programs -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -BashExe ""$BashExe"" $clear -FFmpegUrl $FFmpegUrl -FFmpegCommit $FFmpegCommit $skipPkgConfig $addparams"
         $processes[$platform] = $proc
     
         # only build PkgConfigFake once
@@ -592,7 +602,7 @@ else
 if ($success -and $NugetPackageVersion)
 {
     nuget pack .\Build\FFmpegInteropX.$WindowsTarget.FFmpeg.nuspec `
-        -Properties "id=FFmpegInteropX.$WindowsTarget.FFmpeg;repositoryUrl=$FFmpegUrl;repositoryCommit=$FFmpegCommit;winsdk=$WindowsTargetPlatformVersion;NoWarn=NU5128" `
+        -Properties "id=FFmpegInteropX.$WindowsTarget.FFmpeg;repositoryUrl=$FFmpegUrl;repositoryCommit=$FFmpegCommit;winsdk=$WindowsTargetPlatformMinVersion;NoWarn=NU5128" `
         -Version $NugetPackageVersion `
         -Symbols -SymbolPackageFormat symbols.nupkg `
         -OutputDirectory "${PSScriptRoot}\Output\NuGet"

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -15,8 +15,8 @@ param(
     #>
     [version] $VcVersion = '14.5',
 
-    [ValidateSet('UWP', 'Desktop')]
-    [string] $WindowsTarget = 'UWP',
+    [ValidateSet('Desktop', 'UWP')]
+    [string[]] $WindowsTargets = ('Desktop', 'UWP'),
 
     <#
         Example values:
@@ -86,9 +86,7 @@ function Build-Platform {
     param (
         [System.IO.DirectoryInfo] $SolutionDir,
         [string] $Platform,
-        [string] $Configuration,
-        [version] $WindowsTargetPlatformVersion,
-        [version] $VcVersion,
+        [string] $WindowsTarget,
         [string] $PlatformToolset,
         [string] $VsLatestPath,
         [string] $BashExe = 'C:\msys64\usr\bin\bash.exe',
@@ -113,7 +111,7 @@ function Build-Platform {
     }
 
     Write-Host
-    Write-Host "Building FFmpeg for Windows 10 ($WindowsTarget) ${Platform} ${Gpl}-gpl ${Encoders}-encoders ${Devices}-devices ${Programs}-programs ..."
+    Write-Host "Building FFmpeg for Windows ($WindowsTarget) ${Platform} ${Gpl}-gpl ${Encoders}-encoders ${Devices}-devices ${Programs}-programs ..."
     Write-Host
 
     # Load environment from VCVARS.
@@ -491,7 +489,7 @@ if ($NugetPackageVersion)
 $start = Get-Date
 $success = 1
 
-if ($AllowParallelBuilds -and $Platforms.Count -gt 1)
+if ($AllowParallelBuilds -and ($Platforms.Count * $WindowsTargets.Count -gt 1))
 {
     $processes = @{}
     $clear = ""
@@ -511,30 +509,39 @@ if ($AllowParallelBuilds -and $Platforms.Count -gt 1)
         $addparams += " -SkipConfigureFFmpeg"
     }
 
-    $skipPkgConfig = "" 
-    foreach ($platform in $Platforms) {
-        if ($SkipBuildPkgConfigFake)
-        {
-            $skip
-        }
-        $proc = Start-Process -PassThru powershell "-File .\Build-FFmpeg.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion -Configuration $Configuration -SharedOrStatic $SharedOrStatic -Gpl $Gpl -Encoders $Encoders -Devices $Devices -Programs $Programs -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -BashExe ""$BashExe"" $clear -FFmpegUrl $FFmpegUrl -FFmpegCommit $FFmpegCommit $skipPkgConfig $addparams"
-        $processes[$platform] = $proc
-    
-        # only build PkgConfigFake once
+    $skipPkgConfig = ""
+    if ($SkipBuildPkgConfigFake)
+    {
         $skipPkgConfig = "-SkipBuildPkgConfigFake"
     }
 
-    foreach ($platform in $Platforms) {
-        $processes[$platform].WaitForExit();
-        $result = $processes[$platform].ExitCode;
-        if ($result -eq 0)
+    foreach ($WindowsTarget in $WindowsTargets)
+    {
+        foreach ($platform in $Platforms)
         {
-            Write-Host "Build for $platform succeeded!"
+            $proc = Start-Process -PassThru powershell "-File .\Build-FFmpeg.ps1 -Platforms $platform -WindowsTargets $WindowsTarget -VcVersion $VcVersion -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion -Configuration $Configuration -SharedOrStatic $SharedOrStatic -Gpl $Gpl -Encoders $Encoders -Devices $Devices -Programs $Programs -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -BashExe ""$BashExe"" $clear -FFmpegUrl $FFmpegUrl -FFmpegCommit $FFmpegCommit $skipPkgConfig $addparams"
+            $processes["${WindowsTarget}_$platform"] = $proc
+    
+            # only build PkgConfigFake once
+            $skipPkgConfig = "-SkipBuildPkgConfigFake"
         }
-        else
+    }
+
+    foreach ($WindowsTarget in $WindowsTargets)
+    {
+        foreach ($platform in $Platforms)
         {
-            Write-Host "Build for $platform failed with ErrorCode: $result"
-            $success = 0
+            $processes["${WindowsTarget}_$platform"].WaitForExit();
+            $result = $processes["${WindowsTarget}_$platform"].ExitCode;
+            if ($result -eq 0)
+            {
+                Write-Host "Build for $WindowsTarget $platform succeeded!"
+            }
+            else
+            {
+                Write-Host "Build for $WindowsTarget $platform failed with ErrorCode: $result"
+                $success = 0
+            }
         }
     }
 }
@@ -547,64 +554,68 @@ else
         $oldEnv.Add($item.Name, $item.Value);
     }
 
-    foreach ($platform in $Platforms) {
+    foreach ($WindowsTarget in $WindowsTargets)
+    {
+        foreach ($platform in $Platforms) {
 
-        try { Stop-Transcript } catch { }
-    
-        $logFile = "${PSScriptRoot}\Intermediate\FFmpeg$WindowsTarget\Build_" + $timestamp + "_$platform.log"
-
-        try
-        {
-            Build-Platform `
-                -SolutionDir "${PSScriptRoot}\" `
-                -Platform $platform `
-                -Configuration 'Release' `
-                -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
-                -VcVersion $VcVersion `
-                -PlatformToolset $platformToolSet `
-                -VsLatestPath $vsLatestPath `
-                -BashExe $BashExe `
-                -LogFileName $logFile `
-                -SkipBuildPkgConfigFake $SkipBuildPkgConfigFake `
-                -SkipBuildLibs $SkipBuildLibs `
-                -SkipConfigureFFmpeg $SkipConfigureFFmpeg
-        }
-        catch
-        {
-            Write-Warning "Error occured: $PSItem"
-            $success = 0
-            Break
-        }
-        finally
-        {
             try { Stop-Transcript } catch { }
     
-            # Restore orignal environment variables
-            foreach ($item in $oldEnv.GetEnumerator())
+            $logFile = "${PSScriptRoot}\Intermediate\FFmpeg$WindowsTarget\Build_" + $timestamp + "_$platform.log"
+
+            try
             {
-                Set-Item -Path env:"$($item.Name)" -Value $item.Value
+                Build-Platform `
+                    -SolutionDir "${PSScriptRoot}\" `
+                    -Platform $platform `
+                    -WindowsTarget $WindowsTarget `
+                    -PlatformToolset $platformToolSet `
+                    -VsLatestPath $vsLatestPath `
+                    -BashExe $BashExe `
+                    -LogFileName $logFile `
+                    -SkipBuildPkgConfigFake $SkipBuildPkgConfigFake `
+                    -SkipBuildLibs $SkipBuildLibs `
+                    -SkipConfigureFFmpeg $SkipConfigureFFmpeg
             }
-            foreach ($item in Get-ChildItem env:)
+            catch
             {
-                if (!$oldEnv.ContainsKey($item.Name))
+                Write-Warning "Error occured: $PSItem"
+                $success = 0
+                Break
+            }
+            finally
+            {
+                try { Stop-Transcript } catch { }
+    
+                # Restore orignal environment variables
+                foreach ($item in $oldEnv.GetEnumerator())
                 {
-                     Remove-Item -Path env:"$($item.Name)"
+                    Set-Item -Path env:"$($item.Name)" -Value $item.Value
+                }
+                foreach ($item in Get-ChildItem env:)
+                {
+                    if (!$oldEnv.ContainsKey($item.Name))
+                    {
+                         Remove-Item -Path env:"$($item.Name)"
+                    }
                 }
             }
-        }
    
-        # only build PkgConfigFake once
-        $BuildPkgConfigFake = $false;
+            # only build PkgConfigFake once
+            $BuildPkgConfigFake = $false;
+        }
     }
 }
 
 if ($success -and $NugetPackageVersion)
 {
-    nuget pack .\Build\FFmpegInteropX.$WindowsTarget.FFmpeg.nuspec `
-        -Properties "id=FFmpegInteropX.$WindowsTarget.FFmpeg;repositoryUrl=$FFmpegUrl;repositoryCommit=$FFmpegCommit;winsdk=$WindowsTargetPlatformMinVersion;NoWarn=NU5128" `
-        -Version $NugetPackageVersion `
-        -Symbols -SymbolPackageFormat symbols.nupkg `
-        -OutputDirectory "${PSScriptRoot}\Output\NuGet"
+    foreach ($WindowsTarget in $WindowsTargets)
+    {
+        nuget pack .\Build\FFmpegInteropX.$WindowsTarget.FFmpeg.nuspec `
+            -Properties "id=FFmpegInteropX.$WindowsTarget.FFmpeg;repositoryUrl=$FFmpegUrl;repositoryCommit=$FFmpegCommit;winsdk=$WindowsTargetPlatformMinVersion;NoWarn=NU5128" `
+            -Version $NugetPackageVersion `
+            -Symbols -SymbolPackageFormat symbols.nupkg `
+            -OutputDirectory "${PSScriptRoot}\Output\NuGet"
+    }
 }
 
 Write-Host

--- a/Build-FFmpeg.ps1
+++ b/Build-FFmpeg.ps1
@@ -72,7 +72,7 @@ param(
 
     [string] $FFmpegCommit = $(git --git-dir $PSScriptRoot/Libs/ffmpeg/.git rev-parse HEAD),
 
-    [switch] $AllowParallelBuilds,
+    [switch] $DisableParallelBuilds,
 
     [switch] $SkipBuildPkgConfigFake,
     
@@ -489,7 +489,7 @@ if ($NugetPackageVersion)
 $start = Get-Date
 $success = 1
 
-if ($AllowParallelBuilds -and ($Platforms.Count * $WindowsTargets.Count -gt 1))
+if (!($DisableParallelBuilds) -and ($Platforms.Count * $WindowsTargets.Count -gt 1))
 {
     $processes = @{}
     $clear = ""

--- a/Build-FFmpegInteropX.ps1
+++ b/Build-FFmpegInteropX.ps1
@@ -14,7 +14,7 @@ param(
         Note. The PlatformToolset will be inferred from this value ('v141', 'v142'...)
     #>
     [version] $VcVersion = '14.5',
-
+    
     <#
         Example values:
         8.1
@@ -23,6 +23,15 @@ param(
         10.0.18362.0
     #>
     [version] $WindowsTargetPlatformVersion = '10.0.26100.0',
+    
+    <#
+        Example values:
+        8.1
+        10.0.15063.0
+        10.0.17763.0
+        10.0.18362.0
+    #>
+    [version] $WindowsTargetPlatformMinVersion = '10.0.17763.0',
 
     [ValidateSet('UWP', 'Desktop')]
     [string] $WindowsTarget = 'UWP',
@@ -86,6 +95,7 @@ function Build-Platform {
         /p:Configuration=${Configuration}_${WindowsTarget} `
         /p:Platform=$Platform `
         /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+        /p:WindowsTargetPlatformMinVersion=$WindowsTargetPlatformMinVersion `
         /p:PlatformToolset=$PlatformToolset,
         /p:LibraryVersionNumber=$LibraryVersionNumber
 
@@ -99,6 +109,7 @@ function Build-Platform {
             /p:Configuration=${Configuration}_${WindowsTarget} `
             /p:Platform=$Platform `
             /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+            /p:WindowsTargetPlatformMinVersion=$WindowsTargetPlatformMinVersion `
             /p:TargetFramework="net6.0-windows$WindowsTargetPlatformVersion" `
             /p:AssemblyVersion=$LibraryVersionNumber `
             /p:FileVersion=$LibraryVersionNumber
@@ -175,7 +186,7 @@ if ($AllowParallelBuilds -and $Platforms.Count -gt 1)
             continue;
         }
 
-        $proc = Start-Process -PassThru powershell "-File .\Build-FFmpegInteropX.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -Configuration $Configuration -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -FFmpegInteropXUrl ""$FFmpegInteropXUrl"" -FFmpegInteropXBranch ""FFmpegInteropXBranch"" -FFmpegInteropXCommit ""$FFmpegInteropXCommit"" -LibraryVersionNumber $LibraryVersionNumber $addparams"
+        $proc = Start-Process -PassThru powershell "-File .\Build-FFmpegInteropX.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion -Configuration $Configuration -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -FFmpegInteropXUrl ""$FFmpegInteropXUrl"" -FFmpegInteropXBranch ""FFmpegInteropXBranch"" -FFmpegInteropXCommit ""$FFmpegInteropXCommit"" -LibraryVersionNumber $LibraryVersionNumber $addparams"
         $processes[$platform] = $proc
     }
 
@@ -245,7 +256,7 @@ else
 if ($success -and $NugetPackageVersion)
 {
     nuget pack .\Build\FFmpegInteropX.$WindowsTarget.Lib.nuspec `
-        -Properties "id=FFmpegInteropX.$WindowsTarget.Lib;configuration=$Configuration;repositoryUrl=$FFmpegInteropXUrl;repositoryBranch=$FFmpegInteropXBranch;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformVersion;NoWarn=NU5128" `
+        -Properties "id=FFmpegInteropX.$WindowsTarget.Lib;configuration=$Configuration;repositoryUrl=$FFmpegInteropXUrl;repositoryBranch=$FFmpegInteropXBranch;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformMinVersion;NoWarn=NU5128" `
         -Version $NugetPackageVersion `
         -Symbols -SymbolPackageFormat symbols.nupkg `
         -OutputDirectory "Output\NuGet"

--- a/Build-FFmpegInteropX.ps1
+++ b/Build-FFmpegInteropX.ps1
@@ -23,7 +23,7 @@ param(
         10.0.18362.0
     #>
     [version] $WindowsTargetPlatformVersion = '10.0.26100.0',
-    
+
     <#
         Example values:
         8.1
@@ -33,8 +33,8 @@ param(
     #>
     [version] $WindowsTargetPlatformMinVersion = '10.0.17763.0',
 
-    [ValidateSet('UWP', 'Desktop')]
-    [string] $WindowsTarget = 'UWP',
+    [ValidateSet('Desktop', 'UWP')]
+    [string[]] $WindowsTargets = @('Desktop', 'UWP'),
 
     [ValidateSet('Debug', 'Release')]
     [string] $Configuration = 'Release',
@@ -48,6 +48,8 @@ param(
 
     [switch] $AllowParallelBuilds,
 
+    [switch] $SkipNugetRestore,
+
     # If a version string is specified, a NuGet package will be created.
     [string] $NugetPackageVersion = $null,
 
@@ -59,13 +61,14 @@ param(
 
     [string] $FFmpegInteropXBranch = $(git branch --show-current),
     
-    [string] $FFmpegInteropXCommit = $(git --git-dir Libs/ffmpeg/.git rev-parse HEAD)
+    [string] $FFmpegInteropXCommit = $(git rev-parse HEAD)
 )
 
 function Build-Platform {
     param (
         [System.IO.DirectoryInfo] $SolutionDir,
         [string] $Platform,
+        [string] $WindowsTarget,
         [string] $PlatformToolset,
         [string] $VsLatestPath,
         [version] $LibraryVersionNumber
@@ -74,7 +77,7 @@ function Build-Platform {
     $PSBoundParameters | Out-String
 
     Write-Host
-    Write-Host "Building FFmpegInteropX for Windows 10 ${Platform}..."
+    Write-Host "Building FFmpegInteropX for Windows $WindowsTarget ${Platform}..."
     Write-Host
 
     # Load environment from VCVARS.
@@ -152,10 +155,13 @@ foreach ($item in Get-ChildItem env:)
 $start = Get-Date
 $success = 1
 
-# Restore nuget packets for solution
-nuget.exe restore ${PSScriptRoot}\FFmpegInteropX.sln
+if (!$SkipNugetRestore)
+{
+    # Restore nuget packets for solution
+    nuget.exe restore ${PSScriptRoot}\FFmpegInteropX.sln
+    if ($lastexitcode -ne 0) { throw "Failed to restore NuGet packages." }
+}
 
-if ($lastexitcode -ne 0) { throw "Failed to restore NuGet packages." }
 
 if ($NugetPackageVersion -and !$LibraryVersionNumber) {
     $versionPart = ($NugetPackageVersion -Split '-')[0];
@@ -173,80 +179,91 @@ if ($AllowParallelBuilds -and $Platforms.Count -gt 1)
 {
     $processes = @{}
 
-    $addparams = ""
+    $addparams = "-SkipNugetRestore"
     if ($ClearBuildFolders)
     {
         $addparams += " -ClearBuildFolders"
     }
 
-    foreach ($platform in $Platforms) {
-        # WinUI does not support ARM
-        if ($WindowsTarget -eq "Desktop" -and $platform -eq "ARM")
-        {
-            continue;
-        }
+    foreach ($WindowsTarget in $WindowsTargets)
+    {
+        foreach ($platform in $Platforms) {
+            # WinUI does not support ARM
+            if ($WindowsTarget -eq "Desktop" -and $platform -eq "ARM")
+            {
+                continue;
+            }
 
-        $proc = Start-Process -PassThru powershell "-File .\Build-FFmpegInteropX.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion -Configuration $Configuration -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -FFmpegInteropXUrl ""$FFmpegInteropXUrl"" -FFmpegInteropXBranch ""FFmpegInteropXBranch"" -FFmpegInteropXCommit ""$FFmpegInteropXCommit"" -LibraryVersionNumber $LibraryVersionNumber $addparams"
-        $processes[$platform] = $proc
+            $proc = Start-Process -PassThru powershell "-File .\Build-FFmpegInteropX.ps1 -Platforms $platform -WindowsTargets $WindowsTarget -VcVersion $VcVersion -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion -Configuration $Configuration -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -FFmpegInteropXUrl ""$FFmpegInteropXUrl"" -FFmpegInteropXBranch ""$FFmpegInteropXBranch"" -FFmpegInteropXCommit ""$FFmpegInteropXCommit"" -LibraryVersionNumber $LibraryVersionNumber $addparams"
+            $processes["${WindowsTarget}_$platform"] = $proc
+        }
     }
 
-    foreach ($platform in $Platforms) {
-        # WinUI does not support ARM
-        if ($WindowsTarget -eq "Desktop" -and $platform -eq "ARM")
+    foreach ($WindowsTarget in $WindowsTargets)
+    {
+        foreach ($platform in $Platforms)
         {
-            continue;
-        }
+            # WinUI does not support ARM
+            if ($WindowsTarget -eq "Desktop" -and $platform -eq "ARM")
+            {
+                continue;
+            }
 
-        $processes[$platform].WaitForExit();
-        $result = $processes[$platform].ExitCode;
-        if ($result -eq 0)
-        {
-            Write-Host "Build for $platform succeeded!"
-        }
-        else
-        {
-            Write-Host "Build for $platform failed with ErrorCode: $result"
-            $success = 0
+            $processes["${WindowsTarget}_$platform"].WaitForExit();
+            $result = $processes["${WindowsTarget}_$platform"].ExitCode;
+            if ($result -eq 0)
+            {
+                Write-Host "Build for $WindowsTarget $platform succeeded!"
+            }
+            else
+            {
+                Write-Host "Build for $WindowsTarget $platform failed with ErrorCode: $result"
+                $success = 0
+            }
         }
     }
 }
 else
 {
-    foreach ($platform in $Platforms) {
-
-        # WinUI does not support ARM
-        if ($WindowsTarget -eq "Desktop" -and $platform -eq "ARM")
+    foreach ($WindowsTarget in $WindowsTargets)
+    {
+        foreach ($platform in $Platforms)
         {
-            continue;
-        }
-
-        try
-        {
-            Build-Platform `
-                -SolutionDir "${PSScriptRoot}\" `
-                -Platform $platform `
-                -PlatformToolset $platformToolSet `
-                -VsLatestPath $vsLatestPath `
-                -LibraryVersionNumber $LibraryVersionNumber
-        }
-        catch
-        {
-            Write-Warning "Error occured: $PSItem"
-            $success = 0
-            Break
-        }
-        finally
-        {
-            # Restore orignal environment variables
-            foreach ($item in $oldEnv.GetEnumerator())
+            # WinUI does not support ARM
+            if ($WindowsTarget -eq "Desktop" -and $platform -eq "ARM")
             {
-                Set-Item -Path env:"$($item.Name)" -Value $item.Value
+                continue;
             }
-            foreach ($item in Get-ChildItem env:)
+
+            try
             {
-                if (!$oldEnv.ContainsKey($item.Name))
+                Build-Platform `
+                    -SolutionDir "${PSScriptRoot}\" `
+                    -Platform $platform `
+                    -WindowsTarget $WindowsTarget `
+                    -PlatformToolset $platformToolSet `
+                    -VsLatestPath $vsLatestPath `
+                    -LibraryVersionNumber $LibraryVersionNumber
+            }
+            catch
+            {
+                Write-Warning "Error occured: $PSItem"
+                $success = 0
+                Break
+            }
+            finally
+            {
+                # Restore orignal environment variables
+                foreach ($item in $oldEnv.GetEnumerator())
                 {
-                     Remove-Item -Path env:"$($item.Name)"
+                    Set-Item -Path env:"$($item.Name)" -Value $item.Value
+                }
+                foreach ($item in Get-ChildItem env:)
+                {
+                    if (!$oldEnv.ContainsKey($item.Name))
+                    {
+                         Remove-Item -Path env:"$($item.Name)"
+                    }
                 }
             }
         }
@@ -255,11 +272,14 @@ else
 
 if ($success -and $NugetPackageVersion)
 {
-    nuget pack .\Build\FFmpegInteropX.$WindowsTarget.Lib.nuspec `
-        -Properties "id=FFmpegInteropX.$WindowsTarget.Lib;configuration=$Configuration;repositoryUrl=$FFmpegInteropXUrl;repositoryBranch=$FFmpegInteropXBranch;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformMinVersion;NoWarn=NU5128" `
-        -Version $NugetPackageVersion `
-        -Symbols -SymbolPackageFormat symbols.nupkg `
-        -OutputDirectory "Output\NuGet"
+    foreach ($WindowsTarget in $WindowsTargets)
+    {
+        nuget pack .\Build\FFmpegInteropX.$WindowsTarget.Lib.nuspec `
+            -Properties "id=FFmpegInteropX.$WindowsTarget.Lib;configuration=$Configuration;repositoryUrl=$FFmpegInteropXUrl;repositoryBranch=$FFmpegInteropXBranch;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformMinVersion;NoWarn=NU5128" `
+            -Version $NugetPackageVersion `
+            -Symbols -SymbolPackageFormat symbols.nupkg `
+            -OutputDirectory "Output\NuGet"
+    }
 }
 
 Write-Host

--- a/Build-FFmpegInteropX.ps1
+++ b/Build-FFmpegInteropX.ps1
@@ -46,7 +46,7 @@ param(
 
     [switch] $ClearBuildFolders,
 
-    [switch] $AllowParallelBuilds,
+    [switch] $DisableParallelBuilds,
 
     [switch] $SkipNugetRestore,
 
@@ -175,7 +175,7 @@ if (!$LibraryVersionNumber)
 
 Write-Host "LibraryVersionNumber: $LibraryVersionNumber"
 
-if ($AllowParallelBuilds -and $Platforms.Count -gt 1)
+if (!($DisableParallelBuilds) -and ($Platforms.Count * $WindowsTargets.Count -gt 1))
 {
     $processes = @{}
 

--- a/Build-OverallPackage.ps1
+++ b/Build-OverallPackage.ps1
@@ -1,18 +1,18 @@
 param(
 
-    # If a version string is specified, a NuGet package will be created.
+    # The version number of the overall NuGet package to create.
     [string] $NugetPackageVersion,
 
-    # If a version string is specified, a NuGet package will be created.
+    # The referenced FFmpeg NuGet package version to use in the overall NuGet package.
     [string] $FFmpegPackageVersion,
 
-    # If a version string is specified, a NuGet package will be created.
+    # The referenced FFmpegInteropX library version to use in the overall NuGet package.
     [string] $LibPackageVersion,
 
     [ValidateSet('UWP', 'Desktop')]
     [string[]] $WindowsTargets = ('Desktop', 'UWP'),
 
-    [version] $WindowsTargetPlatformVersion = '10.0.22000.0',
+    [version] $WindowsTargetPlatformMinVersion = '10.0.17763.0',
 
     # FFmpegInteropX NuGet settings
     [string] $FFmpegInteropXUrl = 'https://github.com/ffmpeginteropx/FFmpegInteropX.git',
@@ -24,14 +24,14 @@ param(
 
 if ($WindowsTargets -contains 'Desktop') {
     nuget pack .\Build\FFmpegInteropX.nuspec `
-        -Properties "id=FFmpegInteropX;repositoryUrl=$FFmpegInteropXUrl;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
+        -Properties "id=FFmpegInteropX;repositoryUrl=$FFmpegInteropXUrl;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformMinVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
         -Version $NugetPackageVersion `
         -OutputDirectory "${PSScriptRoot}\Output\NuGet" `
 }
 
 if ($WindowsTargets -contains 'UWP') {
     nuget pack .\Build\FFmpegInteropX.UWP.nuspec `
-        -Properties "id=FFmpegInteropX.UWP;repositoryUrl=$FFmpegInteropXUrl;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
+        -Properties "id=FFmpegInteropX.UWP;repositoryUrl=$FFmpegInteropXUrl;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformMinVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
         -Version $NugetPackageVersion `
         -OutputDirectory "${PSScriptRoot}\Output\NuGet" `
 }

--- a/Build-OverallPackage.ps1
+++ b/Build-OverallPackage.ps1
@@ -9,6 +9,9 @@ param(
     # If a version string is specified, a NuGet package will be created.
     [string] $LibPackageVersion,
 
+    [ValidateSet('UWP', 'Desktop')]
+    [string[]] $WindowsTargets = ('Desktop', 'UWP'),
+
     [version] $WindowsTargetPlatformVersion = '10.0.22000.0',
 
     # FFmpegInteropX NuGet settings
@@ -19,9 +22,16 @@ param(
     [string] $FFmpegInteropXCommit = $(git --git-dir Libs/ffmpeg/.git rev-parse HEAD)
 )
 
+if ($WindowsTargets -contains 'Desktop') {
+    nuget pack .\Build\FFmpegInteropX.nuspec `
+        -Properties "id=FFmpegInteropX;repositoryUrl=$FFmpegInteropXUrl;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
+        -Version $NugetPackageVersion `
+        -OutputDirectory "${PSScriptRoot}\Output\NuGet" `
+}
 
-nuget pack .\Build\FFmpegInteropX.nuspec `
-    -Properties "id=FFmpegInteropX;repositoryUrl=$FFmpegInteropXUrl;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
-    -Version $NugetPackageVersion `
-    -OutputDirectory "${PSScriptRoot}\Output\NuGet" `
-	
+if ($WindowsTargets -contains 'UWP') {
+    nuget pack .\Build\FFmpegInteropX.UWP.nuspec `
+        -Properties "id=FFmpegInteropX.UWP;repositoryUrl=$FFmpegInteropXUrl;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
+        -Version $NugetPackageVersion `
+        -OutputDirectory "${PSScriptRoot}\Output\NuGet" `
+}

--- a/Build-OverallPackage.ps1
+++ b/Build-OverallPackage.ps1
@@ -1,13 +1,13 @@
 param(
 
-    # The version number of the overall NuGet package to create.
-    [string] $NugetPackageVersion,
-
     # The referenced FFmpeg NuGet package version to use in the overall NuGet package.
     [string] $FFmpegPackageVersion,
 
     # The referenced FFmpegInteropX library version to use in the overall NuGet package.
     [string] $LibPackageVersion,
+
+    # The version number of the overall NuGet package to create.
+    [string] $OverallPackageVersion = $null,
 
     [ValidateSet('UWP', 'Desktop')]
     [string[]] $WindowsTargets = ('Desktop', 'UWP'),
@@ -19,19 +19,34 @@ param(
 
     [string] $FFmpegInteropXBranch = $(git branch --show-current),
     
-    [string] $FFmpegInteropXCommit = $(git --git-dir Libs/ffmpeg/.git rev-parse HEAD)
+    [string] $FFmpegInteropXCommit = $(git rev-parse HEAD)
 )
+
+if (!$OverallPackageVersion)
+{
+    # Get version from LibPackageVersion (remove prerelease suffix if present)
+    $libPart = $LibPackageVersion -replace '-.*$', '' # Remove prerelease suffix
+
+    # Get Revision by concatenating first three parts of FFmpeg version
+    $ffmpegPart = $FFmpegPackageVersion -replace '-.*$', '' # Remove prerelease suffix
+    $revisionPart = [string]::Join("", ($ffmpegPart -split '\.' | Select-Object -First 3))
+    $revisionEnd = "00"
+
+    # Get prerelease suffix from LibPackageVersion (if present)
+    $prereleasePart = $LibPackageVersion -replace '^[0-9]+\.[0-9]+\.[0-9]+', '' # Remove first three parts
+    $OverallPackageVersion = "$libPart.$revisionPart$revisionEnd$prereleasePart"
+}
 
 if ($WindowsTargets -contains 'Desktop') {
     nuget pack .\Build\FFmpegInteropX.nuspec `
         -Properties "id=FFmpegInteropX;repositoryUrl=$FFmpegInteropXUrl;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformMinVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
-        -Version $NugetPackageVersion `
+        -Version $OverallPackageVersion `
         -OutputDirectory "${PSScriptRoot}\Output\NuGet" `
 }
 
 if ($WindowsTargets -contains 'UWP') {
     nuget pack .\Build\FFmpegInteropX.UWP.nuspec `
         -Properties "id=FFmpegInteropX.UWP;repositoryUrl=$FFmpegInteropXUrl;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformMinVersion;libversion=$LibPackageVersion;ffmpegversion=$FFmpegPackageVersion;NoWarn=NU5128" `
-        -Version $NugetPackageVersion `
+        -Version $OverallPackageVersion `
         -OutputDirectory "${PSScriptRoot}\Output\NuGet" `
 }

--- a/Build-VideoEffects.ps1
+++ b/Build-VideoEffects.ps1
@@ -22,7 +22,16 @@ param(
         10.0.17763.0
         10.0.18362.0
     #>
-    [version] $WindowsTargetPlatformVersion = '10.0.22000.0',
+    [version] $WindowsTargetPlatformVersion = '10.0.26100.0',
+    
+    <#
+        Example values:
+        8.1
+        10.0.15063.0
+        10.0.17763.0
+        10.0.18362.0
+    #>
+    [version] $WindowsTargetPlatformMinVersion = '10.0.17763.0',
 
     [ValidateSet('UWP', 'Desktop')]
     [string] $WindowsTarget = 'UWP',
@@ -86,6 +95,7 @@ function Build-Platform {
         /p:Configuration=${Configuration}_${WindowsTarget} `
         /p:Platform=$Platform `
         /p:WindowsTargetPlatformVersion=$WindowsTargetPlatformVersion `
+        /p:WindowsTargetPlatformMinVersion=$WindowsTargetPlatformMinVersion `
         /p:PlatformToolset=$PlatformToolset,
         /p:LibraryVersionNumber=$LibraryVersionNumber
 
@@ -158,7 +168,7 @@ if ($AllowParallelBuilds -and $Platforms.Count -gt 1)
             continue;
         }
 
-        $proc = Start-Process -PassThru powershell "-File .\Build-VideoEffects.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -Configuration $Configuration -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -FFmpegInteropXUrl ""$FFmpegInteropXUrl"" -FFmpegInteropXBranch ""FFmpegInteropXBranch"" -FFmpegInteropXCommit ""$FFmpegInteropXCommit"" -LibraryVersionNumber $LibraryVersionNumber $addparams"
+        $proc = Start-Process -PassThru powershell "-File .\Build-VideoEffects.ps1 -Platforms $platform -VcVersion $VcVersion -WindowsTarget $WindowsTarget -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion -Configuration $Configuration -VSInstallerFolder ""$VSInstallerFolder"" -VsWhereCriteria ""$VsWhereCriteria"" -FFmpegInteropXUrl ""$FFmpegInteropXUrl"" -FFmpegInteropXBranch ""FFmpegInteropXBranch"" -FFmpegInteropXCommit ""$FFmpegInteropXCommit"" -LibraryVersionNumber $LibraryVersionNumber $addparams"
         $processes[$platform] = $proc
     }
 
@@ -228,7 +238,7 @@ else
 if ($success -and $NugetPackageVersion)
 {
     nuget pack .\Build\FFmpegInteropX.$WindowsTarget.VideoEffects.nuspec `
-        -Properties "id=FFmpegInteropX.$WindowsTarget.VideoEffects;repositoryUrl=$FFmpegInteropXUrl;repositoryBranch=$FFmpegInteropXBranch;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformVersion;NoWarn=NU5128" `
+        -Properties "id=FFmpegInteropX.$WindowsTarget.VideoEffects;repositoryUrl=$FFmpegInteropXUrl;repositoryBranch=$FFmpegInteropXBranch;repositoryCommit=$FFmpegInteropXCommit;winsdk=$WindowsTargetPlatformMinVersion;NoWarn=NU5128" `
         -Version $NugetPackageVersion `
         -Symbols -SymbolPackageFormat symbols.nupkg `
         -OutputDirectory "Output\NuGet"

--- a/Build-VideoEffects.ps1
+++ b/Build-VideoEffects.ps1
@@ -46,7 +46,7 @@ param(
 
     [switch] $ClearBuildFolders,
 
-    [switch] $AllowParallelBuilds,
+    [switch] $DisableParallelBuilds,
 
     # If a version string is specified, a NuGet package will be created.
     [string] $NugetPackageVersion = $null,
@@ -151,7 +151,7 @@ if (!$LibraryVersionNumber)
 
 Write-Host "LibraryVersionNumber: $LibraryVersionNumber"
 
-if ($AllowParallelBuilds -and $Platforms.Count -gt 1)
+if (!($DisableParallelBuilds) -and (Platforms.Count -gt 1))
 {
     $processes = @{}
 

--- a/Build/FFmpegConfig.sh
+++ b/Build/FFmpegConfig.sh
@@ -73,7 +73,7 @@ ldflags=""
 
 if [ "$variant" == "UWP" ]; then
 
-    ldflags="$ldflags -APPCONTAINER WindowsApp.lib"
+    ldflags="$ldflags -APPCONTAINER WindowsApp.lib dxguid.lib"
 
     cflags="\
         $cflags \
@@ -84,7 +84,7 @@ fi
 
 if [ "$variant" == "Desktop" ]; then
 
-    ldflags="$ldflags -APPCONTAINER:NO -MACHINE:$platform Ws2_32.lib Advapi32.lib User32.lib"
+    ldflags="$ldflags -APPCONTAINER:NO -MACHINE:$platform Ws2_32.lib Advapi32.lib User32.lib dxguid.lib"
 
     if [ "$sharedOrStatic" = "shared" ]; then
         cflags="$cflags -D_WINDLL"

--- a/Build/FFmpegConfig.sh
+++ b/Build/FFmpegConfig.sh
@@ -24,6 +24,7 @@ outDir="$DIR/Output/$folderName/$platform"
 #Main
 echo "Make $variant $platform $sharedOrStatic $gpl-glp $encoders-encoders $devices-encoders $programs-programs" $8
 mkdir -p $intDir
+mkdir -p $outDir
 cd $intDir
 
 configureArgs="\
@@ -73,6 +74,8 @@ ldflags=""
 
 if [ "$variant" == "UWP" ]; then
 
+    configureArgs="$configureArgs --disable-filter=gfxcapture"
+
     ldflags="$ldflags -APPCONTAINER WindowsApp.lib dxguid.lib"
 
     cflags="\
@@ -116,14 +119,23 @@ cflags="$cflags -wd\"4267\" -wd\"4133\" -wd\"4334\" -wd\"4101\" "
 configureArgs="\
     $configureArgs \
     --extra-cflags='$cflags' \
+    --extra-cxxflags='$cflags' \
     --extra-ldflags='$ldflags'
 "
 
+# Perform configure (unless skipped)
 if [ "$9" != "-SkipConfigure" ]; then
     eval $DIR/Libs/ffmpeg/configure $configureArgs || exit 1
 fi
 
+# Perform the build
 make -j$(nproc) || exit
+
+# Clean output directory before install
+rm -r $outDir/*
+mkdir $outDir/licenses
+
+# Install files
 make install || exit
 
 exit 0

--- a/Build/FFmpegInteropX.UWP.FFmpeg.nuspec
+++ b/Build/FFmpegInteropX.UWP.FFmpeg.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">LGPL-2.1-or-later AND Zlib AND MIT</license>
     <dependencies>
-      <group targetFramework="uap10.0" />
+      <group targetFramework="uap$winsdk$" />
       <group targetFramework="net6.0-windows$winsdk$" />
     </dependencies>
     <repository type="git" url="$repositoryUrl$" commit="$repositoryCommit$" />

--- a/Build/FFmpegInteropX.UWP.Lib.nuspec
+++ b/Build/FFmpegInteropX.UWP.Lib.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <dependencies>
-      <group targetFramework="uap10.0.17763.0" />
+      <group targetFramework="uap$winsdk$" />
       <group targetFramework="net6.0-windows$winsdk$">
         <dependency id="Microsoft.Windows.CsWinRT" version="2.2.0" />
       </group>

--- a/Build/FFmpegInteropX.UWP.nuspec
+++ b/Build/FFmpegInteropX.UWP.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <dependencies>
-      <group targetFramework="uap10.0.17763.0">
+      <group targetFramework="uap$winsdk$">
         <dependency id="FFmpegInteropX.UWP.Lib" version="$libversion$" />
         <dependency id="FFmpegInteropX.UWP.FFmpeg" version="$ffmpegversion$" />
       </group>

--- a/Build/FFmpegInteropX.UWP.nuspec
+++ b/Build/FFmpegInteropX.UWP.nuspec
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <description>FFmpeg decoding library for Windows Apps (UWP Classic and UWP .Net9+)</description>
+    <authors>FFmpegInteropX</authors>
+    <readme>docs\README.md</readme>
+    <projectUrl>https://github.com/ffmpeginteropx/FFmpegInteropX</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <dependencies>
+      <group targetFramework="uap10.0.17763.0">
+        <dependency id="FFmpegInteropX.UWP.Lib" version="$libversion$" />
+        <dependency id="FFmpegInteropX.UWP.FFmpeg" version="$ffmpegversion$" />
+      </group>
+      <group targetFramework="net6.0-windows$winsdk$">
+        <dependency id="FFmpegInteropX.UWP.Lib" version="$libversion$" />
+        <dependency id="FFmpegInteropX.UWP.FFmpeg" version="$ffmpegversion$" />
+      </group>
+      <group targetFramework="native">
+        <dependency id="FFmpegInteropX.UWP.Lib" version="$libversion$" />
+        <dependency id="FFmpegInteropX.UWP.FFmpeg" version="$ffmpegversion$" />
+      </group>
+    </dependencies>
+    <repository type="git" url="$repositoryUrl$" branch="$repositoryBranch$" commit="$repositoryCommit$" />
+  </metadata>
+
+  <files>
+
+    <file src="..\README.md" target="docs\" />
+
+  </files>
+  
+</package>

--- a/Build/FFmpegInteropX.nuspec
+++ b/Build/FFmpegInteropX.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
     <dependencies>
-      <group targetFramework="uap10.0.17763.0">
+      <group targetFramework="uap$winsdk$">
         <dependency id="FFmpegInteropX.UWP.Lib" version="$libversion$" />
         <dependency id="FFmpegInteropX.UWP.FFmpeg" version="$ffmpegversion$" />
       </group>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.26100.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion Condition="'$(WindowsTargetPlatformMinVersion)' == ''">10.0.17763.0</WindowsTargetPlatformMinVersion>
+    <FFmpegPackageVersion Condition="'$(FFmpegPackageVersion)'==''">8.1.2-pre01</FFmpegPackageVersion>
+    <FFmpegInteropXPackageVersion Condition="'$(FFmpegInteropXPackageVersion)'==''">2.1.0-pre10</FFmpegInteropXPackageVersion>
   </PropertyGroup>
 
   <!-- User overrides -->

--- a/README.md
+++ b/README.md
@@ -4,35 +4,10 @@
 
 ## Welcome to FFmpegInteropX
 
-FFmpegInteropX is an open-source project that aims to provide an easy way to use **FFmpeg** as a decoder library in **Windows 10/11 UWP Apps**. This allows you to decode a lot of formats that are not natively supported on Windows 10/11. Please note that only decoding is supported currently, we provide no encoding or transcoding support.
+FFmpegInteropX is an open-source project that aims to provide an easy way to use **FFmpeg** as a decoder library in **Windows 10/11 Apps (UWP, WinUI, Desktop)**. This allows you to decode a lot of formats that are not natively supported on Windows 10/11. The lib can be used as a source for MediaPlayer, but it also provides a FrameGrabber class. Please note that only decoding is supported currently, we provide no encoding or transcoding support at this time.
 
-FFmpegInteropX is a much **improved fork** of the original [Microsoft project](git://github.com/Microsoft/FFmpegInterop).
+FFmpegInteropX was originally based on the [Microsoft project](git://github.com/Microsoft/FFmpegInterop), but was heavily improved and later more or less completely re-written as C++/WinRT code.
 
-#### Latest Releases:
-- [FFmpegInteropX](https://www.nuget.org/packages/FFmpegInteropX):
-  - 1.0.0
-    - Renamed namespaces and classes
-    - Removed deprecated APIs and code cleanup
-  - 0.9.4
-    - Support for HDR video!
-  - 0.9.3
-    - Support for AV1 hardware and software decoding
-    - Dynamic detection of AV1 hardware decoding capabilities
-- [FFmpegInteropX.FFmpegUWP](https://www.nuget.org/packages/FFmpegInteropX.FFmpegUWP): 
-  - 5.1.100
-    - FFmpeg 5.1.1 build for UWP platform
-    - Includes unofficial "init_threads" option to speedup DASH stream loading
-  - 5.0.0
-    - FFmpeg 5.0.0 build for UWP platform
-  - 4.4.100
-    - FFmpeg 4.4.1 build for UWP platform
-    - Added AV1 hardware decoder
-    - Added dav1d library for AV1 software decoding
-    - Added openssl 3.0.1 for secure streaming support (e.g. https, rtmps)
-    - Build system improvements:
-      - Added dockerfile for building inside container (experimental)
-      - Automatic download and installation of all dependencies (both dockerfile and local build)
-      - Support for building all target platforms in parallel
 
 ### Some of the important improvements, compared to original version:
 
@@ -62,25 +37,40 @@ FFmpegInteropX is a much **improved fork** of the original [Microsoft project](g
 
 ## How to work with FFmpegInteropX
 
-We have switched from manual builds to providing NuGet packages. There are two packages: 
+We have switched from manual builds to providing NuGet packages. There are two top-level packages: 
 
 - [**FFmpegInteropX**](https://www.nuget.org/packages/FFmpegInteropX)
-  - The library itself, referenced by app project files
-  - Has a dependency on FFmpegInteropX.FFmpegUWP, which contains the actual FFmpeg build
+  - This is the normal top-level package.
+  - It references the lib and the ffmpeg build, based on project type (either UWP or desktop version).
+  - Can be used in:
+    - Windows desktop apps (WinUI3, other/no UI, console)
+    - UWP apps (.NET Native)
+    - UWP with .NET 9 and higher (partly supported):
+      This will reference the normal desktop version of the lib and ffmpeg build, not the UWP version. This works on the PC, but it is recommended to use the FFmpegInteropX.UWP(https://www.nuget.org/packages/FFmpegInteropX.UWP) package instead. On XBOX you definitely must use FFmpegInteropX.UWP(https://www.nuget.org/packages/FFmpegInteropX.UWP) for .NET9 and higher!
 
-- [**FFmpegInteropX.FFmpegUWP**](https://www.nuget.org/packages/FFmpegInteropX.FFmpegUWP)
-  - Our official FFmpeg build for the UWP platform
-  - Customized and tested for use with FFmpegInteropX
-  - Includes FFFmpeg dll files, libs, includes and license files
-  - Two purposes:
-    - Provide runtime dependencies (dlls) for apps
-    - Provide build dependencies for our library
+- [**FFmpegInteropX.UWP**](https://www.nuget.org/packages/FFmpegInteropX.UWP)
+  - This references the UWP version of the lib and ffmpeg
+  - Works with UWP apps (.NET Native) and UWP with .NET 9 and higher (on XBOX, you must use this package for .NET9 and higher!)
 
-The easiest way to work with FFmpegInteropX is to add both NuGet packages to your app. This allows full usage of all features, without checking out the repo or installing build tools.
+These are the lower level packages, which are referenced by the top-level packages:
+
+- [**FFmpegInteropX.Desktop.Lib**](https://www.nuget.org/packages/FFmpegInteropX.UWP.Lib)
+  - The Desktop lib package
+
+- [**FFmpegInteropX.Desktop.FFmpeg**](https://www.nuget.org/packages/FFmpegInteropX.UWP.FFmpeg)
+  - The Desktop ffmpeg package
+
+- [**FFmpegInteropX.UWP.Lib**](https://www.nuget.org/packages/FFmpegInteropX.UWP.Lib)
+  - The UWP lib package
+
+- [**FFmpegInteropX.UWP.FFmpeg**](https://www.nuget.org/packages/FFmpegInteropX.UWP.FFmpeg)
+  - The UWP ffmpeg package
+
+Directly using the lower level packages would allow you to e.g. use only our lib, but provide your own ffmpeg build with it.
 
 **Advanced users and library developers:** If you want to be able to debug into FFmpegInteropX right from your app, or to work on the library, you need to clone this repository. Instead of adding the FFmpegInteropX NuGet package to your app, you can directly add the `Source\FFmpegInteropX.vcxproj` project file to your app solution (it does not matter where the FFmpegInteropX folder is located). Then in your main app project, add a reference to the FFmpegInteropX project. Now you have all the sources directly in your app solution and can debug and enhance the lib.
 
-**Full blown:** If needed, you can even supply your own custom FFmpeg build to replace our FFmpegInteropX.FFmpegUWP NuGet package.
+**Full blown:** If needed, you can even supply your own custom FFmpeg build to replace our FFmpeg NuGet package.
 
 Check out the [build instructions](README-BUILD.md) if you want to manually build FFmpgeInteropX or FFmpeg itself.
 
@@ -182,21 +172,46 @@ src.SendFFmpegAudioFilterCommand("volume", "volume", "1.0");
 src.SendFFmpegAudioFilterCommand("equalizer", "g", "5");
 ```
 
-#### Version History:
-- [FFmpegInteropX](https://www.nuget.org/packages/FFmpegInteropX): 0.9.2
-  - Native D3D11 hardware acceleration!!
-  - FFmpeg video filters
-  - Fast seeking to keyframes
-  - Stereo downmix option
-  - Improved support for image file formats
-- [FFmpegInteropX.FFmpegUWP](https://www.nuget.org/packages/FFmpegInteropX.FFmpegUWP): 4.3.100
-  - FFmpeg 4.3.1 build for UWP platform
-  - D3D11 hardware acceleration enabled
+#### Version History (older versions, not provided in GitHub releases):
+- [FFmpegInteropX](https://www.nuget.org/packages/FFmpegInteropX):
+  - 1.0.0
+    - Renamed namespaces and classes
+    - Removed deprecated APIs and code cleanup
+  - 0.9.4
+    - Support for HDR video!
+  - 0.9.3
+    - Support for AV1 hardware and software decoding
+    - Dynamic detection of AV1 hardware decoding capabilities
+  - 0.9.2
+    - Native D3D11 hardware acceleration!!
+    - FFmpeg video filters
+    - Fast seeking to keyframes
+    - Stereo downmix option
+    - Improved support for image file formats
+- [FFmpegInteropX.FFmpegUWP](https://www.nuget.org/packages/FFmpegInteropX.FFmpegUWP):
+  - 5.1.100
+    - FFmpeg 5.1.1 build for UWP platform
+    - Includes unofficial "init_threads" option to speedup DASH stream loading
+  - 5.0.0
+    - FFmpeg 5.0.0 build for UWP platform
+  - 4.4.100
+    - FFmpeg 4.4.1 build for UWP platform
+    - Added AV1 hardware decoder
+    - Added dav1d library for AV1 software decoding
+    - Added openssl 3.0.1 for secure streaming support (e.g. https, rtmps)
+    - Build system improvements:
+      - Added dockerfile for building inside container (experimental)
+      - Automatic download and installation of all dependencies (both dockerfile and local build)
+      - Support for building all target platforms in parallel
+  - 4.3.100
+    - FFmpeg 4.3.1 build for UWP platform
+    - D3D11 hardware acceleration enabled
 
 ## Credits / major contributors
 
 - [lukasf](https://github.com/lukasf)
-- [mcosmin222](https://github.com/mcosmin222)
+- [Brabebhin](https://github.com/brabebhin)
+- [softworkz](https://github.com/softworkz)
 - [MouriNaruto](https://github.com/MouriNaruto)
 - [JunielKatarn](https://github.com/JunielKatarn)
 

--- a/Release.ps1
+++ b/Release.ps1
@@ -61,6 +61,68 @@ param(
 
 )
 
+
+function Test-Package-Local {
+    param (
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $PackageName,
+        [Parameter(Mandatory=$true, Position=1)]
+        [string] $PackageVersion
+    )
+
+    return Test-Path(".\Output\NuGet\$PackageName.$PackageVersion.nupkg")
+}
+
+function Test-Package-Online {
+    param (
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $PackageName,
+        [Parameter(Mandatory=$true, Position=1)]
+        [string] $PackageVersion
+    )
+
+    Write-Host "Checking online for $PackageName $PackageVersion..."
+
+    Write-Host "dotnet package search $PackageName --exact-match --prerelease --format json --source $NuGetPackageSource | ConvertFrom-Json"
+    $res = dotnet package search $PackageName --exact-match --prerelease --format json --source $NuGetPackageSource | ConvertFrom-Json
+    $package = $res.searchResult[0].packages | Where-Object { $_.version -eq $PackageVersion }
+
+    if ($package) {
+        Write-Host "Package found!"
+        return $true
+    } else {
+        Write-Host "Package not found!"
+        return $false
+    }
+}
+
+function Invoke() {
+    # A handy way to run a command, and automatically throw an error if the
+    # exit code is non-zero.
+
+    if ($args.Count -eq 0) {
+        throw "Must supply some arguments."
+    }
+
+    $command = $args[0]
+    $commandArgs = @()
+    if ($args.Count -gt 1) {
+        $commandArgs = $args[1..($args.Count - 1)]
+    }
+
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+
+    & $command $commandArgs | Out-Default
+    $result = $LASTEXITCODE
+
+    $ErrorActionPreference = $old
+
+    if ($result -ne 0) {
+        throw "$command $commandArgs exited with code $result.`r`nOriginal command line:`r`n$command $commandArgs"
+    }
+}
+
 if (!$LibraryVersionNumber)
 {
     # Get LibraryVersionNumber from LibraryPackageNumber (remove prerelease suffix if present, add .0 if missing)
@@ -85,6 +147,7 @@ if (!$OverallPackageVersion)
     $OverallPackageVersion = "$libPart.$revisionPart$revisionEnd$prereleasePart"
 }
 
+$start = Get-Date
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 
 Write-Host
@@ -117,48 +180,61 @@ $OverallPackages = @(
     ".\Output\NuGet\FFmpegInteropX.UWP.$OverallPackageVersion.nupkg"
 )
 
-if ((!(Test-Path $LibPackages[0])) -or (!(Test-Path $LibPackages[1])))
-{
-    Write-Host
-    Write-Host "Building FFmpegInteropX Lib..."
-    Write-Host
+$PushPackages = @()
 
-    .\Build-FFmpegInteropX.ps1 `
-        -VcVersion $VcVersion `
-        -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
-        -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion `
-        -VcVersion $VcVersion `
-        -LibraryVersionNumber $LibraryVersionNumber `
-        -NugetPackageVersion $LibPackageVersion `
-        -ClearBuildFolders:$ClearBuildFolders `
-        -AllowParallelBuilds:$AllowParallelBuilds
-    
-    if ((!(Test-Path $LibPackages[0])) -or (!(Test-Path $LibPackages[1])))
+if ((!(Test-Package-Local -PackageName "FFmpegInteropX.Desktop.Lib" -PackageVersion $LibPackageVersion)) -or (!(Test-Package-Local -PackageName "FFmpegInteropX.UWP.Lib" -PackageVersion $LibPackageVersion)))
+{
+    if ((!(Test-Package-Online -PackageName "FFmpegInteropX.Desktop.Lib" -PackageVersion $LibPackageVersion)) -or (!(Test-Package-Online -PackageName "FFmpegInteropX.UWP.Lib" -PackageVersion $LibPackageVersion)))
     {
-        Write-Warning "Failed to build FFmpegInteropX Lib..."
-        Exit 1
+        Write-Host
+        Write-Host "Building FFmpegInteropX Lib..."
+        Write-Host
+
+        .\Build-FFmpegInteropX.ps1 `
+            -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
+            -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion `
+            -VcVersion $VcVersion `
+            -LibraryVersionNumber $LibraryVersionNumber `
+            -NugetPackageVersion $LibPackageVersion `
+            -ClearBuildFolders:$ClearBuildFolders `
+            -AllowParallelBuilds:$AllowParallelBuilds
+
+        $PushPackages += $LibPackages[0]
+        $PushPackages += $LibPackages[1]
     }
 }
-
-if ((!(Test-Path $FFmpegPackages[0])) -or (!(Test-Path $FFmpegPackages[1])))
+else
 {
-    Write-Host
-    Write-Host "Building FFmpegInteropX FFmpeg..."
-    Write-Host
+    $PushPackages += $LibPackages[0]
+    $PushPackages += $LibPackages[1]
+}
 
-    .\Build-FFmpeg.ps1 `
-        -VcVersion $VcVersion `
-        -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
-        -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion `
-        -NugetPackageVersion $FFmpegPackageVersion `
-        -ClearBuildFolders:$ClearBuildFolders `
-        -AllowParallelBuilds:$AllowParallelBuilds
-
-    if ((!(Test-Path $FFmpegPackages[0])) -or (!(Test-Path $FFmpegPackages[1])))
+if ((!(Test-Package-Local -PackageName "FFmpegInteropX.Desktop.FFmpeg" -PackageVersion $FFmpegPackageVersion)) -or (!(Test-Package-Local -PackageName "FFmpegInteropX.UWP.FFmpeg" -PackageVersion $FFmpegPackageVersion)))
+{
+    if ((!(Test-Package-Online -PackageName "FFmpegInteropX.Desktop.FFmpeg" -PackageVersion $FFmpegPackageVersion)) -or (!(Test-Package-Online -PackageName "FFmpegInteropX.UWP.FFmpeg" -PackageVersion $FFmpegPackageVersion)))
     {
-        Write-Warning "Failed to build FFmpegInteropX FFmpeg."
-        Exit 1
-    }
+        Write-Host
+        Write-Host "Building FFmpegInteropX FFmpeg..."
+        Write-Host
+
+        .\Build-FFmpeg.ps1 `
+            -VcVersion $VcVersion `
+            -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
+            -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion `
+            -NugetPackageVersion $FFmpegPackageVersion `
+            -ClearBuildFolders:$ClearBuildFolders `
+            -AllowParallelBuilds:$AllowParallelBuilds `
+            -SkipConfigureFFmpeg:$SkipConfigureFFmpeg `
+            -SkipBuildLibs:$SkipBuildLibs
+
+        $PushPackages += $FFmpegPackages[0]
+        $PushPackages += $FFmpegPackages[1]
+   }
+}
+else
+{
+    $PushPackages += $FFmpegPackages[0]
+    $PushPackages += $FFmpegPackages[1]
 }
 
 if ((!(Test-Path $OverallPackages[0])) -or (!(Test-Path $OverallPackages[1])))
@@ -172,13 +248,10 @@ if ((!(Test-Path $OverallPackages[0])) -or (!(Test-Path $OverallPackages[1])))
         -FFmpegPackageVersion $FFmpegPackageVersion `
         -LibPackageVersion $LibPackageVersion `
         -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion
-
-    if ((!(Test-Path $OverallPackages[0])) -or (!(Test-Path $OverallPackages[1])))
-    {
-        Write-Warning "Failed to build overall FFmpegInteropX NuGet packages."
-        Exit 1
-    }
 }
+
+$PushPackages += $OverallPackages[0]
+$PushPackages += $OverallPackages[1]
 
 Write-Host
 Read-Host -Prompt "Press 'Return' to publish packages to NuGet"
@@ -187,31 +260,14 @@ Write-Host
 Write-Host "Pushing to NuGet..."
 Write-Host
 
-nuget push $LibPackages[0] -Source $NuGetPackageSource -SkipDuplicate
-if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
-nuget push $LibPackages[1] -Source $NuGetPackageSource -SkipDuplicate
-if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
-nuget push $FFmpegPackages[0] -Source $NuGetPackageSource -SkipDuplicate
-if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
-nuget push $FFmpegPackages[1] -Source $NuGetPackageSource -SkipDuplicate
-if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
-nuget push $OverallPackages[0] -Source $NuGetPackageSource -SkipDuplicate
-if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
-nuget push $OverallPackages[1] -Source $NuGetPackageSource -SkipDuplicate
-if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
+foreach ($package in $PushPackages)
+{
+    Write-Host "Pushing $package..."
+    Invoke nuget push $package -Source $NuGetPackageSource -SkipDuplicate
+}
 
 Write-Host
 Write-Host 'Time elapsed'
 Write-Host ('{0}' -f ((Get-Date) - $start))
 Write-Host
-
-if ($success)
-{
-    Write-Host 'Release succeeded!'
-
-}
-else
-{
-    Write-Warning 'Release failed!'
-    Exit 1
-}
+Write-Host 'Release succeeded!'

--- a/Release.ps1
+++ b/Release.ps1
@@ -53,7 +53,7 @@ param(
 
     [switch] $ClearBuildFolders,
 
-    [switch] $AllowParallelBuilds,
+    [switch] $DisableParallelBuilds,
     
     [switch] $SkipBuildLibs,
     
@@ -61,6 +61,7 @@ param(
 
 )
 
+$PushPackages = [System.Collections.Generic.List[string]]::new()
 
 function Test-Package-Local {
     param (
@@ -81,19 +82,55 @@ function Test-Package-Online {
         [string] $PackageVersion
     )
 
-    Write-Host "Checking online for $PackageName $PackageVersion..."
-
-    Write-Host "dotnet package search $PackageName --exact-match --prerelease --format json --source $NuGetPackageSource | ConvertFrom-Json"
     $res = dotnet package search $PackageName --exact-match --prerelease --format json --source $NuGetPackageSource | ConvertFrom-Json
     $package = $res.searchResult[0].packages | Where-Object { $_.version -eq $PackageVersion }
 
     if ($package) {
-        Write-Host "Package found!"
         return $true
     } else {
-        Write-Host "Package not found!"
         return $false
     }
+}
+
+function Test-Package {
+    param (
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $PackagePostfix,
+        [Parameter(Mandatory=$true, Position=1)]
+        [string] $PackageVersion,
+        [Parameter(Position=2)]
+        [string] $PackagePrefix = "FFmpegInteropX",
+        [Parameter(Position=3)]
+        [array] $WindowsTargets = @("Desktop", "UWP")
+    )
+
+    $NeedPush = @()
+    $NeedBuild = $false
+
+    foreach ($target in $WindowsTargets) {
+        $packageName = "$PackagePrefix.$target.$PackagePostfix"
+
+        Write-Host
+        Write-Host "Checking for package: $packageName $PackageVersion..."
+
+        if (Test-Package-Online -PackageName $packageName -PackageVersion $PackageVersion) {
+            Write-Host "Online package found: $packageName $PackageVersion"
+        } elseif (Test-Package-Local -PackageName $packageName -PackageVersion $PackageVersion) {
+            Write-Host "Local package found: $packageName $PackageVersion"
+            $NeedPush += $packageName
+        } else {
+            Write-Host "Package needs to be built: $packageName $PackageVersion"
+            $NeedPush += $packageName
+            $NeedBuild = $true
+        }
+    }
+
+    foreach ($package in $NeedPush) {
+        Write-Host "Package to push: $package.$PackageVersion"
+        $PushPackages.Add(".\Output\NuGet\$package.$PackageVersion.nupkg")
+    }
+
+    return $NeedBuild
 }
 
 function Invoke() {
@@ -164,78 +201,43 @@ Write-Host
 # Stop on all PowerShell command errors
 $ErrorActionPreference = "Stop"
 
+if (Test-Package "Lib" $LibPackageVersion)
+{
+    Write-Host
+    Write-Host "Building FFmpegInteropX Lib..."
+    Write-Host
 
-$LibPackages = @(
-    ".\Output\NuGet\FFmpegInteropX.Desktop.Lib.$LibPackageVersion.nupkg"
-    ".\Output\NuGet\FFmpegInteropX.UWP.Lib.$LibPackageVersion.nupkg"
-)
+    .\Build-FFmpegInteropX.ps1 `
+        -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
+        -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion `
+        -VcVersion $VcVersion `
+        -LibraryVersionNumber $LibraryVersionNumber `
+        -NugetPackageVersion $LibPackageVersion `
+        -ClearBuildFolders:$ClearBuildFolders `
+        -DisableParallelBuilds:$DisableParallelBuilds
+}
 
-$FFmpegPackages = @(
-    ".\Output\NuGet\FFmpegInteropX.Desktop.FFmpeg.$FFmpegPackageVersion.nupkg"
-    ".\Output\NuGet\FFmpegInteropX.UWP.FFmpeg.$FFmpegPackageVersion.nupkg"
-)
+if (Test-Package "FFmpeg" $FFmpegPackageVersion)
+{
+    Write-Host
+    Write-Host "Building FFmpegInteropX FFmpeg..."
+    Write-Host
+
+    .\Build-FFmpeg.ps1 `
+        -VcVersion $VcVersion `
+        -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
+        -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion `
+        -NugetPackageVersion $FFmpegPackageVersion `
+        -ClearBuildFolders:$ClearBuildFolders `
+        -DisableParallelBuilds:$DisableParallelBuilds `
+        -SkipConfigureFFmpeg:$SkipConfigureFFmpeg `
+        -SkipBuildLibs:$SkipBuildLibs
+}
 
 $OverallPackages = @(
-    ".\Output\NuGet\FFmpegInteropX.$OverallPackageVersion.nupkg"
+    ".\Output\NuGet\FFmpegInteropX.$OverallPackageVersion.nupkg",
     ".\Output\NuGet\FFmpegInteropX.UWP.$OverallPackageVersion.nupkg"
 )
-
-$PushPackages = @()
-
-if ((!(Test-Package-Local -PackageName "FFmpegInteropX.Desktop.Lib" -PackageVersion $LibPackageVersion)) -or (!(Test-Package-Local -PackageName "FFmpegInteropX.UWP.Lib" -PackageVersion $LibPackageVersion)))
-{
-    if ((!(Test-Package-Online -PackageName "FFmpegInteropX.Desktop.Lib" -PackageVersion $LibPackageVersion)) -or (!(Test-Package-Online -PackageName "FFmpegInteropX.UWP.Lib" -PackageVersion $LibPackageVersion)))
-    {
-        Write-Host
-        Write-Host "Building FFmpegInteropX Lib..."
-        Write-Host
-
-        .\Build-FFmpegInteropX.ps1 `
-            -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
-            -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion `
-            -VcVersion $VcVersion `
-            -LibraryVersionNumber $LibraryVersionNumber `
-            -NugetPackageVersion $LibPackageVersion `
-            -ClearBuildFolders:$ClearBuildFolders `
-            -AllowParallelBuilds:$AllowParallelBuilds
-
-        $PushPackages += $LibPackages[0]
-        $PushPackages += $LibPackages[1]
-    }
-}
-else
-{
-    $PushPackages += $LibPackages[0]
-    $PushPackages += $LibPackages[1]
-}
-
-if ((!(Test-Package-Local -PackageName "FFmpegInteropX.Desktop.FFmpeg" -PackageVersion $FFmpegPackageVersion)) -or (!(Test-Package-Local -PackageName "FFmpegInteropX.UWP.FFmpeg" -PackageVersion $FFmpegPackageVersion)))
-{
-    if ((!(Test-Package-Online -PackageName "FFmpegInteropX.Desktop.FFmpeg" -PackageVersion $FFmpegPackageVersion)) -or (!(Test-Package-Online -PackageName "FFmpegInteropX.UWP.FFmpeg" -PackageVersion $FFmpegPackageVersion)))
-    {
-        Write-Host
-        Write-Host "Building FFmpegInteropX FFmpeg..."
-        Write-Host
-
-        .\Build-FFmpeg.ps1 `
-            -VcVersion $VcVersion `
-            -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
-            -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion `
-            -NugetPackageVersion $FFmpegPackageVersion `
-            -ClearBuildFolders:$ClearBuildFolders `
-            -AllowParallelBuilds:$AllowParallelBuilds `
-            -SkipConfigureFFmpeg:$SkipConfigureFFmpeg `
-            -SkipBuildLibs:$SkipBuildLibs
-
-        $PushPackages += $FFmpegPackages[0]
-        $PushPackages += $FFmpegPackages[1]
-   }
-}
-else
-{
-    $PushPackages += $FFmpegPackages[0]
-    $PushPackages += $FFmpegPackages[1]
-}
 
 if ((!(Test-Path $OverallPackages[0])) -or (!(Test-Path $OverallPackages[1])))
 {
@@ -250,8 +252,16 @@ if ((!(Test-Path $OverallPackages[0])) -or (!(Test-Path $OverallPackages[1])))
         -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion
 }
 
-$PushPackages += $OverallPackages[0]
-$PushPackages += $OverallPackages[1]
+$PushPackages.Add($OverallPackages[0])
+$PushPackages.Add($OverallPackages[1])
+
+Write-Host
+Write-Host "Packages to push:"
+
+foreach ($package in $PushPackages)
+{
+    Write-Host " - $package"
+}
 
 Write-Host
 Read-Host -Prompt "Press 'Return' to publish packages to NuGet"

--- a/Release.ps1
+++ b/Release.ps1
@@ -1,0 +1,217 @@
+param(
+    
+    # If a version string is specified, a NuGet package will be created.
+    [string] $LibPackageVersion,
+
+    # If a version string is specified, a NuGet package will be created.
+    [string] $FFmpegPackageVersion,
+
+    # If a version string is specified, a NuGet package will be created.
+    [string] $OverallPackageVersion = $null,
+    
+    # The version number to set in the dll file
+    [version] $LibraryVersionNumber = $null,
+
+    <#
+        Example values:
+        14.1
+        14.2
+        14.16
+        14.16.27023
+        14.23.27820
+
+        Note. The PlatformToolset will be inferred from this value ('v141', 'v142'...)
+    #>
+    [version] $VcVersion = '14.5',
+
+    <#
+        Example values:
+        8.1
+        10.0.15063.0
+        10.0.17763.0
+        10.0.18362.0
+    #>
+    [version] $WindowsTargetPlatformVersion = '10.0.26100.0',
+
+    <#
+        Example values:
+        8.1
+        10.0.15063.0
+        10.0.17763.0
+        10.0.18362.0
+    #>
+    [version] $WindowsTargetPlatformMinVersion = '10.0.17763.0',
+
+    [System.IO.DirectoryInfo] $VSInstallerFolder = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer",
+
+    # Set the search criteria for VSWHERE.EXE.
+    [string[]] $VsWhereCriteria = '-latest',
+
+    [System.IO.FileInfo] $BashExe = 'C:\msys64\usr\bin\bash.exe',
+
+    [string] $NuGetPackageSource = 'https://api.nuget.org/v3/index.json',
+
+    [switch] $ClearBuildFolders,
+
+    [switch] $AllowParallelBuilds,
+    
+    [switch] $SkipBuildLibs,
+    
+    [switch] $SkipConfigureFFmpeg
+
+)
+
+if (!$LibraryVersionNumber)
+{
+    # Get LibraryVersionNumber from LibraryPackageNumber (remove prerelease suffix if present, add .0 if missing)
+    $LibraryVersionNumber = [version]($LibPackageVersion -replace '-.*$', '') # Remove prerelease suffix
+    if ($LibraryVersionNumber.Revision -eq -1) {
+        $LibraryVersionNumber = [version]::new($LibraryVersionNumber.Major, $LibraryVersionNumber.Minor, $LibraryVersionNumber.Build, 0)
+    }
+}
+
+if (!$OverallPackageVersion)
+{
+    # Get version from LibPackageVersion (remove prerelease suffix if present)
+    $libPart = $LibPackageVersion -replace '-.*$', '' # Remove prerelease suffix
+
+    # Get Revision by concatenating first three parts of FFmpeg version
+    $ffmpegPart = $FFmpegPackageVersion -replace '-.*$', '' # Remove prerelease suffix
+    $revisionPart = [string]::Join("", ($ffmpegPart -split '\.' | Select-Object -First 3))
+    $revisionEnd = "00"
+
+    # Get prerelease suffix from LibPackageVersion (if present)
+    $prereleasePart = $LibPackageVersion -replace '^[0-9]+\.[0-9]+\.[0-9]+', '' # Remove first three parts
+    $OverallPackageVersion = "$libPart.$revisionPart$revisionEnd$prereleasePart"
+}
+
+$timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+
+Write-Host
+Write-Host "Releasing FFmpegInteropX..."
+Write-Host
+Write-Host "Overall Package Version:   $OverallPackageVersion"
+Write-Host "Lib Package Version:       $LibPackageVersion"
+Write-Host "Lib DLL Version:           $LibraryVersionNumber"
+Write-Host "FFmpeg Package Version:    $FFmpegPackageVersion"
+Write-Host
+Write-Host "Timestamp: $timestamp"
+Write-Host
+
+# Stop on all PowerShell command errors
+$ErrorActionPreference = "Stop"
+
+
+$LibPackages = @(
+    ".\Output\NuGet\FFmpegInteropX.Desktop.Lib.$LibPackageVersion.nupkg"
+    ".\Output\NuGet\FFmpegInteropX.UWP.Lib.$LibPackageVersion.nupkg"
+)
+
+$FFmpegPackages = @(
+    ".\Output\NuGet\FFmpegInteropX.Desktop.FFmpeg.$FFmpegPackageVersion.nupkg"
+    ".\Output\NuGet\FFmpegInteropX.UWP.FFmpeg.$FFmpegPackageVersion.nupkg"
+)
+
+$OverallPackages = @(
+    ".\Output\NuGet\FFmpegInteropX.$OverallPackageVersion.nupkg"
+    ".\Output\NuGet\FFmpegInteropX.UWP.$OverallPackageVersion.nupkg"
+)
+
+if ((!(Test-Path $LibPackages[0])) -or (!(Test-Path $LibPackages[1])))
+{
+    Write-Host
+    Write-Host "Building FFmpegInteropX Lib..."
+    Write-Host
+
+    .\Build-FFmpegInteropX.ps1 `
+        -VcVersion $VcVersion `
+        -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
+        -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion `
+        -VcVersion $VcVersion `
+        -LibraryVersionNumber $LibraryVersionNumber `
+        -NugetPackageVersion $LibPackageVersion `
+        -ClearBuildFolders:$ClearBuildFolders `
+        -AllowParallelBuilds:$AllowParallelBuilds
+    
+    if ((!(Test-Path $LibPackages[0])) -or (!(Test-Path $LibPackages[1])))
+    {
+        Write-Warning "Failed to build FFmpegInteropX Lib..."
+        Exit 1
+    }
+}
+
+if ((!(Test-Path $FFmpegPackages[0])) -or (!(Test-Path $FFmpegPackages[1])))
+{
+    Write-Host
+    Write-Host "Building FFmpegInteropX FFmpeg..."
+    Write-Host
+
+    .\Build-FFmpeg.ps1 `
+        -VcVersion $VcVersion `
+        -WindowsTargetPlatformVersion $WindowsTargetPlatformVersion `
+        -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion `
+        -NugetPackageVersion $FFmpegPackageVersion `
+        -ClearBuildFolders:$ClearBuildFolders `
+        -AllowParallelBuilds:$AllowParallelBuilds
+
+    if ((!(Test-Path $FFmpegPackages[0])) -or (!(Test-Path $FFmpegPackages[1])))
+    {
+        Write-Warning "Failed to build FFmpegInteropX FFmpeg."
+        Exit 1
+    }
+}
+
+if ((!(Test-Path $OverallPackages[0])) -or (!(Test-Path $OverallPackages[1])))
+{
+    Write-Host
+    Write-Host "Building FFmpegInteropX Overall Packages..."
+    Write-Host
+
+    .\Build-OverallPackage.ps1 `
+        -OverallPackageVersion $OverallPackageVersion `
+        -FFmpegPackageVersion $FFmpegPackageVersion `
+        -LibPackageVersion $LibPackageVersion `
+        -WindowsTargetPlatformMinVersion $WindowsTargetPlatformMinVersion
+
+    if ((!(Test-Path $OverallPackages[0])) -or (!(Test-Path $OverallPackages[1])))
+    {
+        Write-Warning "Failed to build overall FFmpegInteropX NuGet packages."
+        Exit 1
+    }
+}
+
+Write-Host
+Read-Host -Prompt "Press 'Return' to publish packages to NuGet"
+
+Write-Host
+Write-Host "Pushing to NuGet..."
+Write-Host
+
+nuget push $LibPackages[0] -Source $NuGetPackageSource -SkipDuplicate
+if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
+nuget push $LibPackages[1] -Source $NuGetPackageSource -SkipDuplicate
+if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
+nuget push $FFmpegPackages[0] -Source $NuGetPackageSource -SkipDuplicate
+if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
+nuget push $FFmpegPackages[1] -Source $NuGetPackageSource -SkipDuplicate
+if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
+nuget push $OverallPackages[0] -Source $NuGetPackageSource -SkipDuplicate
+if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
+nuget push $OverallPackages[1] -Source $NuGetPackageSource -SkipDuplicate
+if ($lastexitcode -ne 0) { throw "Failed to publish package!" }
+
+Write-Host
+Write-Host 'Time elapsed'
+Write-Host ('{0}' -f ((Get-Date) - $start))
+Write-Host
+
+if ($success)
+{
+    Write-Host 'Release succeeded!'
+
+}
+else
+{
+    Write-Warning 'Release failed!'
+    Exit 1
+}

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -142,12 +142,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\FFmpegInteropX.UWP.FFmpeg.7.0.100-pre3\build\native\FFmpegInteropX.UWP.FFmpeg.targets" Condition="Exists('..\..\packages\FFmpegInteropX.UWP.FFmpeg.7.0.100-pre3\build\native\FFmpegInteropX.UWP.FFmpeg.targets')" />
+    <Import Project="..\..\packages\FFmpegInteropX.UWP.FFmpeg.8.0.300\build\native\FFmpegInteropX.UWP.FFmpeg.targets" Condition="Exists('..\..\packages\FFmpegInteropX.UWP.FFmpeg.8.0.300\build\native\FFmpegInteropX.UWP.FFmpeg.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\FFmpegInteropX.UWP.FFmpeg.7.0.100-pre3\build\native\FFmpegInteropX.UWP.FFmpeg.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FFmpegInteropX.UWP.FFmpeg.7.0.100-pre3\build\native\FFmpegInteropX.UWP.FFmpeg.targets'))" />
+    <Error Condition="!Exists('..\..\packages\FFmpegInteropX.UWP.FFmpeg.8.0.300\build\native\FFmpegInteropX.UWP.FFmpeg.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FFmpegInteropX.UWP.FFmpeg.8.0.300\build\native\FFmpegInteropX.UWP.FFmpeg.targets'))" />
   </Target>
 </Project>

--- a/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
+++ b/Samples/MediaPlayerCPP/MediaPlayerCPP.vcxproj
@@ -10,8 +10,8 @@
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <PlatformToolset>v143</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion>$(WindowsTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>$(WindowsTargetPlatformMinVersion)</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">
@@ -142,12 +142,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\FFmpegInteropX.UWP.FFmpeg.8.0.300\build\native\FFmpegInteropX.UWP.FFmpeg.targets" Condition="Exists('..\..\packages\FFmpegInteropX.UWP.FFmpeg.8.0.300\build\native\FFmpegInteropX.UWP.FFmpeg.targets')" />
+    <Import Project="..\..\packages\FFmpegInteropX.UWP.FFmpeg.$(FFmpegInteropXPackageVersion)\build\native\FFmpegInteropX.UWP.FFmpeg.targets" Condition="Exists('..\..\packages\FFmpegInteropX.UWP.FFmpeg.$(FFmpegInteropXPackageVersion)\build\native\FFmpegInteropX.UWP.FFmpeg.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\FFmpegInteropX.UWP.FFmpeg.8.0.300\build\native\FFmpegInteropX.UWP.FFmpeg.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FFmpegInteropX.UWP.FFmpeg.8.0.300\build\native\FFmpegInteropX.UWP.FFmpeg.targets'))" />
+    <Error Condition="!Exists('..\..\packages\FFmpegInteropX.UWP.FFmpeg.$(FFmpegInteropXPackageVersion)\build\native\FFmpegInteropX.UWP.FFmpeg.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\FFmpegInteropX.UWP.FFmpeg.$(FFmpegInteropXPackageVersion)\build\native\FFmpegInteropX.UWP.FFmpeg.targets'))" />
   </Target>
 </Project>

--- a/Samples/MediaPlayerCPP/packages.config
+++ b/Samples/MediaPlayerCPP/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FFmpegInteropX.UWP.FFmpeg" version="7.0.100-pre3" targetFramework="native" />
+  <package id="FFmpegInteropX.UWP.FFmpeg" version="8.0.300" targetFramework="native" />
 </packages>

--- a/Samples/MediaPlayerCS/MediaPlayerCS.csproj
+++ b/Samples/MediaPlayerCS/MediaPlayerCS.csproj
@@ -154,7 +154,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FFmpegInteropX.UWP.FFmpeg">
-      <Version>7.0.100-pre3</Version>
+      <Version>8.0.300</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>
@@ -170,10 +170,10 @@
           <Project>{9cfa3b3e-b7af-4629-84e2-c962c5b046b1}</Project>
           <Name>FFmpegInteropX</Name>
         </ProjectReference>
-		<ProjectReference Include="..\..\VideoEffects\FFmpegInteropX.VideoEffects.vcxproj">
-		  <Project>{6c4bff5e-7037-4ee8-9c9f-5381c35ba066}</Project>
-		  <Name>FFmpegInteropX.VideoEffects</Name>
-		</ProjectReference>
+        <ProjectReference Include="..\..\VideoEffects\FFmpegInteropX.VideoEffects.vcxproj">
+          <Project>{6c4bff5e-7037-4ee8-9c9f-5381c35ba066}</Project>
+          <Name>FFmpegInteropX.VideoEffects</Name>
+        </ProjectReference>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Samples/MediaPlayerCS/MediaPlayerCS.csproj
+++ b/Samples/MediaPlayerCS/MediaPlayerCS.csproj
@@ -154,7 +154,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FFmpegInteropX.UWP.FFmpeg">
-      <Version>8.0.300</Version>
+      <Version>$(FFmpegPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>
@@ -178,8 +178,8 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="FFmpegInteropX.UWP.Lib" Version="2.0.0-pre7" />
-        <PackageReference Include="FFmpegInteropX.UWP.VideoEffects" Version="2.0.0-pre7" />
+        <PackageReference Include="FFmpegInteropX.UWP.Lib" Version="$(FFmpegInteropXPackageVersion)" />
+        <PackageReference Include="FFmpegInteropX.UWP.VideoEffects" Version="2.0.0" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Samples/MediaPlayerWinUI/MediaPlayerWinUI.csproj
+++ b/Samples/MediaPlayerWinUI/MediaPlayerWinUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <Platforms>x64;x86;ARM64</Platforms>
     <UseWinUI>true</UseWinUI>
@@ -29,7 +29,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="FFmpegInteropX.Desktop.FFmpeg" Version="7.0.100-pre3" />
+    <PackageReference Include="FFmpegInteropX.Desktop.FFmpeg" Version="8.0.300" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />

--- a/Samples/MediaPlayerWinUI/MediaPlayerWinUI.csproj
+++ b/Samples/MediaPlayerWinUI/MediaPlayerWinUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
+    <TargetFramework>net8.0-windows$(WindowsTargetPlatformVersion)</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <Platforms>x64;x86;ARM64</Platforms>
     <UseWinUI>true</UseWinUI>
@@ -29,7 +29,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="FFmpegInteropX.Desktop.FFmpeg" Version="8.0.300" />
+    <PackageReference Include="FFmpegInteropX.Desktop.FFmpeg" Version="$(FFmpegPackageVersion)" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
@@ -62,7 +62,7 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="FFmpegInteropX.Desktop.Lib" Version="2.0.0-pre7" />
+        <PackageReference Include="FFmpegInteropX.Desktop.Lib" Version="$(FFmpegInteropXPackageVersion)" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/Source/FFmpegInteropX.DotNet.csproj
+++ b/Source/FFmpegInteropX.DotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows$(WindowsTargetPlatformVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platform>AnyCPU</Platform>
@@ -31,7 +31,7 @@
   
   <PropertyGroup>
     <DefaultItemExcludes>**\*;*.*</DefaultItemExcludes>
-    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(WindowsTargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <Authors>FFmpegInteropX</Authors>
     <Company>FFmpegInteropX</Company>
     <Description>FFmpeg decoding library for Windows - DotNet adapter dll</Description>

--- a/Source/FFmpegInteropX.vcxproj
+++ b/Source/FFmpegInteropX.vcxproj
@@ -14,7 +14,7 @@
     <ConfigType>Debug</ConfigType>
   </PropertyGroup>
   <PropertyGroup>
-    <FFmpegPackageVersion Condition="'$(FFmpegPackageVersion)'==''">7.0.100-pre3</FFmpegPackageVersion>
+    <FFmpegPackageVersion Condition="'$(FFmpegPackageVersion)'==''">8.0.300</FFmpegPackageVersion>
     <FFmpegPackageIdBase Condition="'$(FFmpegPackageIdBase)'==''">FFmpegInteropX</FFmpegPackageIdBase>
     <FFmpegPackageIdPlatform Condition="'$(FFmpegPackageIdPlatform)'=='' AND '$(AppType)'=='Win32'">Desktop</FFmpegPackageIdPlatform>
     <FFmpegPackageIdPlatform Condition="'$(FFmpegPackageIdPlatform)'=='' AND '$(AppType)'=='UWP'">UWP</FFmpegPackageIdPlatform>

--- a/Source/FFmpegInteropX.vcxproj
+++ b/Source/FFmpegInteropX.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.230524.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.230524.4\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Condition="'$(Configuration)'=='Release_UWP' OR '$(Configuration)'=='Debug_UWP'">
@@ -306,6 +306,7 @@
     <None Include="..\Build\FFmpegInteropX.pfx" />
     <None Include="..\Build\FFmpegInteropX.UWP.Lib.nuspec" />
     <None Include="..\Build\FFmpegInteropX.UWP.Lib.targets" />
+    <None Include="..\Build\FFmpegInteropX.UWP.nuspec" />
     <None Include="..\Build\InstallTools.ps1" />
     <None Include="..\Build\Repack-NuGet.ps1" />
     <None Include="..\Build\Start-DevShell.ps1" />

--- a/Source/FFmpegInteropX.vcxproj
+++ b/Source/FFmpegInteropX.vcxproj
@@ -14,7 +14,6 @@
     <ConfigType>Debug</ConfigType>
   </PropertyGroup>
   <PropertyGroup>
-    <FFmpegPackageVersion Condition="'$(FFmpegPackageVersion)'==''">8.0.300</FFmpegPackageVersion>
     <FFmpegPackageIdBase Condition="'$(FFmpegPackageIdBase)'==''">FFmpegInteropX</FFmpegPackageIdBase>
     <FFmpegPackageIdPlatform Condition="'$(FFmpegPackageIdPlatform)'=='' AND '$(AppType)'=='Win32'">Desktop</FFmpegPackageIdPlatform>
     <FFmpegPackageIdPlatform Condition="'$(FFmpegPackageIdPlatform)'=='' AND '$(AppType)'=='UWP'">UWP</FFmpegPackageIdPlatform>
@@ -314,6 +313,7 @@
     <None Include="..\LICENSE" />
     <None Include="..\README-BUILD.md" />
     <None Include="..\README.md" />
+    <None Include="..\Release.ps1" />
     <None Include="cpp.hint" />
     <None Include="FFmpegInteropX.def" />
     <None Include="packages.config" />

--- a/Source/FFmpegInteropX.vcxproj.filters
+++ b/Source/FFmpegInteropX.vcxproj.filters
@@ -248,6 +248,7 @@
     <ClInclude Include="resource.h">
       <Filter>Resources</Filter>
     </ClInclude>
+    <ClInclude Include="FilterCommandResult.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CodecChecker.cpp" />
@@ -344,6 +345,7 @@
     <ClCompile Include="PlatformInfo.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
+    <ClCompile Include="FilterCommandResult.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="FFmpegInteropX.idl" />

--- a/Source/packages.config
+++ b/Source/packages.config
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FFmpegInteropX.Desktop.FFmpeg" version="7.0.100-pre3" targetFramework="native" />
-  <package id="FFmpegInteropX.UWP.FFmpeg" version="7.0.100-pre3" targetFramework="native" />
+  <package id="FFmpegInteropX.Desktop.FFmpeg" version="8.0.300" targetFramework="native" />
+  <package id="FFmpegInteropX.UWP.FFmpeg" version="8.0.300" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230524.4" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.22621.756" targetFramework="native" />
   <package id="Microsoft.WindowsAppSDK" version="1.4.230913002" targetFramework="native" developmentDependency="true" />

--- a/Source/packages.config
+++ b/Source/packages.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FFmpegInteropX.Desktop.FFmpeg" version="8.0.300" targetFramework="native" />
-  <package id="FFmpegInteropX.UWP.FFmpeg" version="8.0.300" targetFramework="native" />
+  <package id="FFmpegInteropX.Desktop.FFmpeg" version="8.1.2-pre01" targetFramework="native" />
+  <package id="FFmpegInteropX.UWP.FFmpeg" version="8.1.2-pre01" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.230524.4" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.BuildTools" version="10.0.22621.756" targetFramework="native" />
   <package id="Microsoft.WindowsAppSDK" version="1.4.230913002" targetFramework="native" developmentDependency="true" />

--- a/Tests/FFmpegInteropX.UnitTests.csproj
+++ b/Tests/FFmpegInteropX.UnitTests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FFmpegInteropX.Desktop.FFmpeg" Version="7.0.100-pre3" />
+    <PackageReference Include="FFmpegInteropX.Desktop.FFmpeg" Version="8.0.300" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.7" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />

--- a/Tests/FFmpegInteropX.UnitTests.csproj
+++ b/Tests/FFmpegInteropX.UnitTests.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net6.0-windows$(WindowsTargetPlatformVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
     <PlatformTarget>x64</PlatformTarget>
     <OutputType>Library</OutputType>
     <Platforms>x64;x86;ARM64;ARM32</Platforms>
-    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>$(WindowsTargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
   


### PR DESCRIPTION
Originally, I planned to go to ffmpeg 8.1. But it seems to have some compilation issue on the filters assembly. The desktop build seems to work, but on UWP I get a compile error, because it cannot find "libcpmt.lib". The strange thing is, this lib is for static linked desktop vcruntime, but we are building dynamic linked UWP lib. So the lib is wrong in two aspects. I am unsure where it comes from, but it happens on 8.1, on 8.1.1 and 8.1.2. The 8.0 branch is fine.

I assume that the desktop build might also be kind of corrupted (probably partly static linked, partly dynamic linked), so for desktop, I will also stay on 8.0 for now.

@softworkz I noticed that ffmpeg now has a scale_d3d11 filter (I think it is new on ffmpeg 8). Do you know something about it? Could this be using the GPU fixed function scaling, which you mentioned some time back?